### PR TITLE
remove GENERATE_CPP_EXPORTS

### DIFF
--- a/src/psdcore/CMakeLists.txt
+++ b/src/psdcore/CMakeLists.txt
@@ -60,7 +60,6 @@ qt_internal_add_module(PsdCore
         Qt::Gui
     PRIVATE_MODULE_INTERFACE
         Qt::CorePrivate
-    GENERATE_CPP_EXPORTS
 )
 
 ## Scopes:

--- a/src/psdgui/CMakeLists.txt
+++ b/src/psdgui/CMakeLists.txt
@@ -24,7 +24,6 @@ qt_internal_add_module(PsdGui
     PUBLIC_LIBRARIES
         Qt::Gui
         Qt::PsdCore
-    GENERATE_CPP_EXPORTS
 )
 
 ## Scopes:


### PR DESCRIPTION
Qt6.8 で GENERATE_CPP_EXPORTS が削除されていたのでそれに対応してこちらも削除しています。

この修正によって Qt6.7 以前でビルドすることができなくなります
