### PR TITLE
Exporter: qtquick: escape raw newline to \n

### DIFF
--- a/src/plugins/psdexporter/qtquick/qtquick.cpp
+++ b/src/plugins/psdexporter/qtquick/qtquick.cpp
@@ -391,7 +391,7 @@ bool QPsdExporterQtQuickPlugin::exportTo(const QPsdFolderLayerItem *tree, const 
             for (auto &line : lines)
                 if (line.isEmpty())
                     line = " ";
-            element->properties.insert("text", u"\"%1\""_s.arg(lines.join("\n")));
+            element->properties.insert("text", u"\"%1\""_s.arg(lines.join("\\n")));
             element->properties.insert("font.family", u"\"%1\""_s.arg(run.font.family()));
             element->properties.insert("font.pointSize", run.font.pointSizeF() / 1.5 * fontScaleFactor);
             if (run.font.bold())

--- a/tests/auto/psdexporter/regression/data/simple/dot_text.expects/QtQuick/MainWindow.ui.qml
+++ b/tests/auto/psdexporter/regression/data/simple/dot_text.expects/QtQuick/MainWindow.ui.qml
@@ -18,7 +18,7 @@ Item {
             font.pointSize: 20
             height: 58
             horizontalAlignment: Text.AlignHCenter
-            text: "."
+            text: ".\n "
             verticalAlignment: Text.AlignVCenter
             width: 9
             x: 125

--- a/tests/auto/psdexporter/regression/data/simple/nested_layes.expects/QtQuick/MainWindow.ui.qml
+++ b/tests/auto/psdexporter/regression/data/simple/nested_layes.expects/QtQuick/MainWindow.ui.qml
@@ -63,7 +63,7 @@ Item {
                 font.pointSize: 20
                 height: 58
                 horizontalAlignment: Text.AlignHCenter
-                text: "Example1"
+                text: "Example1\n "
                 verticalAlignment: Text.AlignVCenter
                 width: 160
                 x: 50
@@ -121,7 +121,7 @@ Item {
                 font.pointSize: 20
                 height: 58
                 horizontalAlignment: Text.AlignHCenter
-                text: "Example1"
+                text: "Example1\n "
                 verticalAlignment: Text.AlignVCenter
                 width: 160
                 x: 50

--- a/tests/auto/psdexporter/regression/data/simple/single_text.expects/QtQuick/MainWindow.ui.qml
+++ b/tests/auto/psdexporter/regression/data/simple/single_text.expects/QtQuick/MainWindow.ui.qml
@@ -18,7 +18,7 @@ Item {
             font.pointSize: 20
             height: 58
             horizontalAlignment: Text.AlignHCenter
-            text: "Example1"
+            text: "Example1\n "
             verticalAlignment: Text.AlignVCenter
             width: 160
             x: 50

--- a/tests/auto/psdexporter/regression/data/simple/text_and_rect_group.expects/QtQuick/MainWindow.ui.qml
+++ b/tests/auto/psdexporter/regression/data/simple/text_and_rect_group.expects/QtQuick/MainWindow.ui.qml
@@ -46,7 +46,7 @@ Item {
                 font.pointSize: 20
                 height: 58
                 horizontalAlignment: Text.AlignHCenter
-                text: "Example1"
+                text: "Example1\n "
                 verticalAlignment: Text.AlignVCenter
                 width: 160
                 x: 50


### PR DESCRIPTION
QtQuick 出力時に runs 末尾の改行が生の改行コードとして出力されていたのを
エスケープ(\n) するように修正しました。

リグレッションの想定結果も該当箇所だけ修正しています
