### PR TITLE
Psdview reset

### DIFF
--- a/examples/psdcore/app/psdview.cpp
+++ b/examples/psdcore/app/psdview.cpp
@@ -41,6 +41,8 @@ PsdView::Private::Private(PsdView *parent)
 
 void PsdView::Private::modelChanged(PsdTreeItemModel *model)
 {
+    QObject::disconnect(modelConnection);
+
     if (model) {
         modelConnection = QObject::connect(model, &QAbstractItemModel::modelReset, q, &PsdView::reset);
     }
@@ -66,9 +68,6 @@ void PsdView::setModel(PsdTreeItemModel *model)
 {
     if (model == d->model) {
         return;
-    }
-    if (d->model) {
-        disconnect(d->modelConnection);
     }
     d->model = model;
     

--- a/examples/psdcore/app/psdview.cpp
+++ b/examples/psdcore/app/psdview.cpp
@@ -59,7 +59,7 @@ PsdView::PsdView(QWidget *parent)
 
 PsdView::~PsdView() = default;
 
-PsdTreeItemModel *PsdView::model()
+PsdTreeItemModel *PsdView::model() const
 {
     return d->model;
 }

--- a/examples/psdcore/app/psdview.cpp
+++ b/examples/psdcore/app/psdview.cpp
@@ -27,7 +27,7 @@ public:
     QPsdParser psdParser;
     QRubberBand *rubberBand;
     PsdTreeItemModel *model = nullptr;
-    std::array<QMetaObject::Connection, 1> modelConnections;
+    QMetaObject::Connection modelConnection;
 };
 
 PsdView::Private::Private(PsdView *parent)
@@ -49,19 +49,12 @@ void PsdView::setModel(PsdTreeItemModel *model) {
         return;
     }
     if (d->model) {
-        for (const QMetaObject::Connection &connection : d->modelConnections) {
-            disconnect(connection);
-        }
+        disconnect(d->modelConnection);
     }
     d->model = model;
     
     if (d->model) {
-        d->modelConnections = {
-            QObject::connect(d->model, &QAbstractItemModel::modelReset,
-                             this, &PsdView::reset)
-        };
-    } else {
-        d->modelConnections = {};
+        d->modelConnection = QObject::connect(d->model, &QAbstractItemModel::modelReset, this, &PsdView::reset);
     }
 
     reset();

--- a/examples/psdcore/app/psdview.h
+++ b/examples/psdcore/app/psdview.h
@@ -19,6 +19,7 @@ public:
 public slots:
     void setModel(PsdTreeItemModel *model);
     void setItemVisible(quint32 id, bool visible);
+    void reset();
 
 signals:
     void updateText(const QPsdAbstractLayerItem *item);

--- a/examples/psdcore/app/psdview.h
+++ b/examples/psdcore/app/psdview.h
@@ -16,6 +16,8 @@ public:
     PsdView(QWidget *parent = nullptr);
     ~PsdView() override;
 
+    PsdTreeItemModel *model();
+
 public slots:
     void setModel(PsdTreeItemModel *model);
     void setItemVisible(quint32 id, bool visible);
@@ -23,6 +25,7 @@ public slots:
 
 signals:
     void updateText(const QPsdAbstractLayerItem *item);
+    void modelChanged(PsdTreeItemModel *model);
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/examples/psdcore/app/psdview.h
+++ b/examples/psdcore/app/psdview.h
@@ -16,7 +16,7 @@ public:
     PsdView(QWidget *parent = nullptr);
     ~PsdView() override;
 
-    PsdTreeItemModel *model();
+    PsdTreeItemModel *model() const;
 
 public slots:
     void setModel(PsdTreeItemModel *model);

--- a/src/psdcore/qpsdlayertreeitemmodel.cpp
+++ b/src/psdcore/qpsdlayertreeitemmodel.cpp
@@ -240,6 +240,8 @@ QVariant QPsdLayerTreeItemModel::data(const QModelIndex &index, int role) const
 
 void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
 {
+    beginResetModel();
+
     d->treeNodeList.clear();
     d->groupIDs.clear();
     d->groupsMap.clear();
@@ -366,6 +368,8 @@ void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
     while (d->clippingMasks.size() < d->treeNodeList.size()) {
         d->clippingMasks.prepend(QModelIndex());
     }
+
+    endResetModel();
 }
 
 QSize QPsdLayerTreeItemModel::size() const


### PR DESCRIPTION
PsdView の更新処理を setModel から reset に分離して PsdTreeItemModel の更新(具体的には fromParser) → modelReset シグナルから呼び出されるように修正しました