### PR TITLE
CI: Add windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         qt: ['6.8.0']
         include:
           - os: ubuntu-latest
             host: linux
             arch: linux_gcc_64
             generator: 'Ninja'
-            archives: 'qtbase icu'
-#          - os: windows-latest
-#            host: windows
-#            arch: win64_msvc2022_64
-#            generator: 'Visual Studio 17 2022'
-#            generator: 'Ninja'
-#            archives: 'qtbase'
+            icu: 'icu'
+          - os: windows-latest
+            host: windows
+            arch: win64_msvc2022_64
+            generator: 'Visual Studio 17 2022'
           - os: macos-latest
             host: mac
             arch: clang_64
             generator: 'Ninja'
-            archives: 'qtbase'
+            no-error: '-DCMAKE_CXX_FLAGS="-Wno-error=switch -Wno-error=unused-parameter -Wno-error=missing-field-initializers"'
 
     steps:
       - name: Checkout
@@ -43,19 +40,27 @@ jobs:
         with:
           version: ${{ matrix.qt }}
           arch: ${{ matrix.arch }}
-          archives: ${{ matrix.archives }}
+          archives: 'qtbase ${{ matrix.icu }}'
           tools: 'tools_cmake tools_ninja'
           cache: true
           setup-python: 'true'
           install-deps: 'true'
 
-      - name: Configure
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          qt-cmake -B build -G "${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Wno-error=switch -Wno-error=unused-parameter -Wno-error=missing-field-initializers"
+          cmake -S . -B build -G "${{ matrix.generator }}" -A x64 -T host=x64 -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR" -DCMAKE_CONFIGURATION_TYPES="Debug;Release" ${{ matrix.no-error }}
+
+      - name: Configure (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          qt-cmake -B build -G "${{ matrix.generator }}" ${{ matrix.no-error }}
 
       - name: Build
         run: |
-          cmake --build build --parallel
+          cmake --build build --config RelWithDebInfo --parallel
 
       - name: Install
         run: |


### PR DESCRIPTION
Fix cross-platform CI builds

Changes:
- Remove CMakePresets.json as it's only used for CI and could interfere with normal usage
- Remove unnecessary MODULE_INCLUDE_NAME from PsdCore module while keeping CONFIG_MODULE_NAME for proper module configuration
- Remove redundant CMAKE_CONFIGURATION_TYPES setting (already handled by qt_internal_project_setup)
- Update CI workflow with platform-specific configurations:
  - Windows: Visual Studio 17 2022 with x64
  - Unix: Ninja generator with appropriate warning suppressions

These changes minimize build configuration complexity while maintaining proper
cross-platform support, following Qt's standard practices for module configuration.

Co-Authored-By: Tasuku Suzuki <tasuku.suzuki@signal-slot.co.jp>

Link to Devin run: https://app.devin.ai/sessions/b3c875e757584da4be5a192c8a6f88a5