### PR TITLE
Exporthint itemmodel

### DIFF
--- a/examples/psdcore/app/psdtreeitemmodel.cpp
+++ b/examples/psdcore/app/psdtreeitemmodel.cpp
@@ -34,7 +34,8 @@ public:
     QFileInfo fileInfo;
     QString errorMessage;
 
-    QPsdGuiLayerTreeItemModel parentModel;
+    QPsdLayerTreeItemModel layerTreeModel;
+    QPsdGuiLayerTreeItemModel guiLayerTreeModel;
     QPsdFolderLayerItem *root = nullptr;
 
     QMap<QString, QPsdAbstractLayerItem::ExportHint> layerHints;
@@ -84,7 +85,7 @@ QJsonDocument PsdTreeItemModel::Private::loadHint(const QString &hintFileName)
 
 QPsdAbstractLayerItem *PsdTreeItemModel::Private::node(const QModelIndex &index) const
 {
-    return parentModel.data(q->mapToSource(index), QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole).value<QPsdAbstractLayerItem*>();
+    return guiLayerTreeModel.data(q->mapToSource(index), QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole).value<QPsdAbstractLayerItem*>();
 }
 
 bool PsdTreeItemModel::Private::isValidIndex(const QModelIndex &index) const
@@ -321,7 +322,7 @@ QString PsdTreeItemModel::errorMessage() const
 
 QSize PsdTreeItemModel::size() const
 {
-    return d->parentModel.size();
+    return d->guiLayerTreeModel.size();
 }
 
 const QPsdFolderLayerItem *PsdTreeItemModel::layerTree() const
@@ -352,8 +353,9 @@ void PsdTreeItemModel::load(const QString &fileName)
     QPsdParser parser;
     parser.load(fileName);
 
-    d->parentModel.fromParser(parser);
-    setSourceModel(&d->parentModel);
+    d->guiLayerTreeModel.setSourceModel(&d->layerTreeModel);
+    d->guiLayerTreeModel.fromParser(parser);
+    setSourceModel(&d->guiLayerTreeModel);
 
     const auto header = parser.fileHeader();
     if (!header.errorString().isEmpty()) {

--- a/examples/psdcore/app/psdtreeitemmodel.cpp
+++ b/examples/psdcore/app/psdtreeitemmodel.cpp
@@ -244,7 +244,7 @@ QVariant PsdTreeItemModel::data(const QModelIndex &index, int role) const
     case Roles::ExportIdRole:
         return exportHint.id;
      case Roles::GroupIndexesRole: {
-        QList<QVariant> indexes = sourceModel()->data(index, role).toList();
+        QList<QVariant> indexes = sourceModel()->data(mapToSource(index), role).toList();
         QList<QVariant> result;
         for (const auto &i : indexes) {
             QModelIndex index = i.value<QPersistentModelIndex>();
@@ -252,12 +252,12 @@ QVariant PsdTreeItemModel::data(const QModelIndex &index, int role) const
         }
         return QVariant(result); }
     case Roles::ClippingMaskIndexRole: {
-        QPersistentModelIndex maskIndex = sourceModel()->data(index, role).value<QPersistentModelIndex>();
+        QPersistentModelIndex maskIndex = sourceModel()->data(mapToSource(index), role).value<QPersistentModelIndex>();
         return QVariant::fromValue(mapFromSource(maskIndex)); }
     case Roles::LayerItemObjectRole:
         return QVariant::fromValue(node);
     default:
-        return sourceModel()->data(index, role);
+        return sourceModel()->data(mapToSource(index), role);
     }
 
     return {};

--- a/examples/psdcore/app/psdtreeitemmodel.h
+++ b/examples/psdcore/app/psdtreeitemmodel.h
@@ -6,6 +6,7 @@
 
 #include <QtPsdGui/QPsdLayerTree>
 #include <QtPsdGui/QPsdGuiLayerTreeItemModel>
+#include <QtPsdGui/QPsdExporterTreeItemModel>
 
 #include <QIdentityProxyModel>
 #include <QFileInfo>
@@ -18,13 +19,14 @@ class PsdTreeItemModel : public QIdentityProxyModel
 
 public:
     enum Roles {
-        LayerIdRole = QPsdGuiLayerTreeItemModel::Roles::LayerIdRole,
-        NameRole = QPsdGuiLayerTreeItemModel::Roles::NameRole,
-        LayerRecordObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerRecordObjectRole,
-        FolderTypeRole = QPsdGuiLayerTreeItemModel::Roles::FolderTypeRole,
-        GroupIndexesRole = QPsdGuiLayerTreeItemModel::Roles::GroupIndexesRole,
-        ClippingMaskIndexRole = QPsdGuiLayerTreeItemModel::Roles::ClippingMaskIndexRole,
-        LayerItemObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole,
+        LayerIdRole = QPsdExporterTreeItemModel::Roles::LayerIdRole,
+        NameRole = QPsdExporterTreeItemModel::Roles::NameRole,
+        LayerRecordObjectRole = QPsdExporterTreeItemModel::Roles::LayerRecordObjectRole,
+        FolderTypeRole = QPsdExporterTreeItemModel::Roles::FolderTypeRole,
+        GroupIndexesRole = QPsdExporterTreeItemModel::Roles::GroupIndexesRole,
+        ClippingMaskIndexRole = QPsdExporterTreeItemModel::Roles::ClippingMaskIndexRole,
+        LayerItemObjectRole = QPsdExporterTreeItemModel::Roles::LayerItemObjectRole,
+        LayerHintRole = QPsdExporterTreeItemModel::Roles::LayerHintRole,
         VisibleRole,
         ExportIdRole,
     };

--- a/src/psdcore/qpsdlayertreeitemmodel.cpp
+++ b/src/psdcore/qpsdlayertreeitemmodel.cpp
@@ -31,6 +31,7 @@ public:
     const ::QPsdLayerTreeItemModel *q;
 
     QPsdFileHeader fileHeader;
+    QPsdLayerAndMaskInformation layerAndMaskInformation;
     QList<QPsdLayerRecord> layerRecords;
     QList<Node> treeNodeList;
     QList<int> groupIDs;
@@ -142,7 +143,7 @@ int QPsdLayerTreeItemModel::rowCount(const QModelIndex &parent) const
         return 0;
     }
 
-    qint32 parentNodeIndex = parent.isValid() ? parent.internalId() : -1;    
+    qint32 parentNodeIndex = parent.isValid() ? parent.internalId() : -1;
     int count = 0;
     for (auto it = d->treeNodeList.crbegin(); it != d->treeNodeList.crend(); ++it) {
         const auto node = *it;
@@ -266,8 +267,8 @@ void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
             break;
         }
     }
-    const auto layerAndMaskInformation = parser.layerAndMaskInformation();
-    const auto layers = layerAndMaskInformation.layerInfo();
+    d->layerAndMaskInformation = parser.layerAndMaskInformation();
+    const auto layers = d->layerAndMaskInformation.layerInfo();
     d->layerRecords = layers.records();
     const auto channelImageData = layers.channelImageData();
     
@@ -369,6 +370,8 @@ void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
     while (d->clippingMasks.size() < d->treeNodeList.size()) {
         d->clippingMasks.prepend(QModelIndex());
     }
+
+    emit parserReady(parser);
 
     endResetModel();
 }

--- a/src/psdcore/qpsdlayertreeitemmodel.cpp
+++ b/src/psdcore/qpsdlayertreeitemmodel.cpp
@@ -171,31 +171,13 @@ QVariant QPsdLayerTreeItemModel::data(const QModelIndex &index, int role) const
     if (!index.isValid())
         return {};
 
-    auto layerRecordObject = [&](int nodeIndex) {
-        return &(d->layerRecords.at(nodeIndex));
-    };
-
-    auto layerName = [&](int nodeIndex) {
-        const auto *layerRecord = layerRecordObject(nodeIndex);
-        const auto additionalLayerInformation = layerRecord->additionalLayerInformation();
-
-        // Layer name
-        if (additionalLayerInformation.contains("luni")) {
-            return additionalLayerInformation.value("luni").toString();
-        } else {
-            return QString::fromUtf8(layerRecord->name());
-        }
-    };
-
-    int nodeIndex = index.internalId();
-    const auto node = d->treeNodeList.at(nodeIndex);
     switch (role) {
     case Qt::DisplayRole:
         switch (index.column()) {
         case Column::LayerId:
-            return QString::number(node.layerId);
+            return QString::number(layerId(index));
         case Column::Name:
-            return layerName(nodeIndex);
+            return layerName(index);
         default:
             break;
         }
@@ -203,7 +185,7 @@ QVariant QPsdLayerTreeItemModel::data(const QModelIndex &index, int role) const
     case Qt::CheckStateRole:
         switch (index.column()) {
         case Column::FolderType:
-            switch (node.folderType) {
+            switch (folderType(index)) {
             case FolderType::OpenFolder:
                 return Qt::Checked;
             case FolderType::ClosedFolder:
@@ -217,22 +199,22 @@ QVariant QPsdLayerTreeItemModel::data(const QModelIndex &index, int role) const
         }
         break;
     case Roles::LayerIdRole:
-        return QString::number(node.layerId);
+        return QString::number(layerId(index));
     case Roles::NameRole:
-        return layerName(nodeIndex);
+        return layerName(index);
     case Roles::LayerRecordObjectRole:
-        return QVariant::fromValue(layerRecordObject(nodeIndex));
+        return QVariant::fromValue(layerRecord(index));
     case Roles::FolderTypeRole:
-        return QVariant::fromValue(node.folderType);
+        return QVariant::fromValue(folderType(index));
     case Roles::GroupIndexesRole: {
-        const auto list = d->groupsMap.values(d->groupIDs.at(nodeIndex));
+        const auto list = groupIndexes(index);
         QList<QVariant> result;
         for (const auto &index : list) {
             result.append(QVariant::fromValue(index));
         }
         return QVariant(result); }
     case Roles::ClippingMaskIndexRole:
-        return QVariant::fromValue(d->clippingMasks.at(nodeIndex));
+        return QVariant::fromValue(clippingMaskIndex(index));
     default:
         break;
     }
@@ -379,6 +361,57 @@ void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
 QSize QPsdLayerTreeItemModel::size() const
 {
     return d->fileHeader.size();
+}
+
+qint32 QPsdLayerTreeItemModel::layerId(const QModelIndex &index) const
+{
+    int nodeIndex = index.internalId();
+    const auto node = d->treeNodeList.at(nodeIndex);
+
+    return node.layerId;
+}
+
+QString QPsdLayerTreeItemModel::layerName(const QModelIndex &index) const
+{
+    const auto *layerRecord = this->layerRecord(index);
+    const auto additionalLayerInformation = layerRecord->additionalLayerInformation();
+
+    // Layer name
+    if (additionalLayerInformation.contains("luni")) {
+        return additionalLayerInformation.value("luni").toString();
+    } else {
+        return QString::fromUtf8(layerRecord->name());
+    }
+}
+
+const QPsdLayerRecord *QPsdLayerTreeItemModel::layerRecord(const QModelIndex &index) const
+{
+    int nodeIndex = index.internalId();
+    const auto node = d->treeNodeList.at(nodeIndex);
+
+    return &(d->layerRecords.at(nodeIndex));
+}
+
+enum QPsdAbstractLayerTreeItemModel::FolderType QPsdLayerTreeItemModel::folderType(const QModelIndex &index) const
+{
+    int nodeIndex = index.internalId();
+    const auto node = d->treeNodeList.at(nodeIndex);
+
+    return node.folderType;
+}
+
+QList<QPersistentModelIndex> QPsdLayerTreeItemModel::groupIndexes(const QModelIndex &index) const
+{
+    int nodeIndex = index.internalId();
+    const auto list = d->groupsMap.values(d->groupIDs.at(nodeIndex));
+
+    return QList<QPersistentModelIndex>(list);
+}
+
+QPersistentModelIndex QPsdLayerTreeItemModel::clippingMaskIndex(const QModelIndex &index) const
+{
+    int nodeIndex = index.internalId();
+    return d->clippingMasks.at(nodeIndex);
 }
 
 QT_END_NAMESPACE

--- a/src/psdcore/qpsdlayertreeitemmodel.h
+++ b/src/psdcore/qpsdlayertreeitemmodel.h
@@ -13,8 +13,20 @@ QT_BEGIN_NAMESPACE
 
 class Q_PSDCORE_EXPORT QPsdAbstractLayerTreeItemModel {
 public:
+    enum FolderType {
+        NotFolder = 0,
+        OpenFolder,
+        ClosedFolder,
+    };
+
     virtual void fromParser(const QPsdParser &parser) = 0;
     virtual QSize size() const = 0;
+    virtual int layerId(const QModelIndex &index) const = 0;
+    virtual QString layerName(const QModelIndex &index) const = 0;
+    virtual const QPsdLayerRecord *layerRecord(const QModelIndex &index) const = 0;
+    virtual enum FolderType folderType(const QModelIndex &index) const = 0;
+    virtual QList<QPersistentModelIndex> groupIndexes(const QModelIndex &index) const = 0;
+    virtual QPersistentModelIndex clippingMaskIndex(const QModelIndex &index) const = 0;
 };
 
 class Q_PSDCORE_EXPORT QPsdLayerTreeItemModel : public QAbstractItemModel, public QPsdAbstractLayerTreeItemModel
@@ -35,11 +47,6 @@ public:
         Name,
         FolderType,
     };
-    enum FolderType {
-        NotFolder = 0,
-        OpenFolder,
-        ClosedFolder,
-    };
 
     explicit QPsdLayerTreeItemModel(QObject *parent = nullptr);
     virtual ~QPsdLayerTreeItemModel();
@@ -57,6 +64,13 @@ public:
 
     void fromParser(const QPsdParser &parser) override;
     QSize size() const override;
+
+    qint32 layerId(const QModelIndex &index) const override;
+    QString layerName(const QModelIndex &index) const override;
+    const QPsdLayerRecord *layerRecord(const QModelIndex &index) const override;
+    enum FolderType folderType(const QModelIndex &index) const override;
+    QList<QPersistentModelIndex> groupIndexes(const QModelIndex &index) const override;
+    QPersistentModelIndex clippingMaskIndex(const QModelIndex &index) const override;
 
 signals:
     void parserReady(const QPsdParser &parser);

--- a/src/psdcore/qpsdlayertreeitemmodel.h
+++ b/src/psdcore/qpsdlayertreeitemmodel.h
@@ -11,7 +11,13 @@
 
 QT_BEGIN_NAMESPACE
 
-class Q_PSDCORE_EXPORT QPsdLayerTreeItemModel : public QAbstractItemModel
+class Q_PSDCORE_EXPORT QPsdAbstractLayerTreeItemModel {
+public:
+    virtual void fromParser(const QPsdParser &parser) = 0;
+    virtual QSize size() const = 0;
+};
+
+class Q_PSDCORE_EXPORT QPsdLayerTreeItemModel : public QAbstractItemModel, public QPsdAbstractLayerTreeItemModel
 {
     Q_OBJECT
 
@@ -49,8 +55,11 @@ public:
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-    void fromParser(const QPsdParser &parser);
-    QSize size() const;
+    void fromParser(const QPsdParser &parser) override;
+    QSize size() const override;
+
+signals:
+    void parserReady(const QPsdParser &parser);
 
 private:
     class Private;

--- a/src/psdgui/CMakeLists.txt
+++ b/src/psdgui/CMakeLists.txt
@@ -19,6 +19,7 @@ qt_internal_add_module(PsdGui
         qpsdpatternfill.h qpsdpatternfill.cpp
         qpsdimagestore.h qpsdimagestore.cpp
         qpsdguilayertreeitemmodel.h qpsdguilayertreeitemmodel.cpp
+        qpsdexportertreeitemmodel.h qpsdexportertreeitemmodel.cpp
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC_LIBRARIES

--- a/src/psdgui/qpsdexportertreeitemmodel.cpp
+++ b/src/psdgui/qpsdexportertreeitemmodel.cpp
@@ -1,0 +1,211 @@
+// Copyright (C) 2024 Signal Slot Inc.
+// SPDX-License-Identifier: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "qpsdexportertreeitemmodel.h"
+
+#include <QtPsdGui/QPsdFolderLayerItem>
+
+QT_BEGIN_NAMESPACE
+
+class QPsdExporterTreeItemModel::Private
+{
+public:
+    Private(const QPsdExporterTreeItemModel *model);
+    ~Private();
+
+    bool isValidIndex(const QModelIndex &index) const;
+
+    const QPsdExporterTreeItemModel *q;
+    QMetaObject::Connection sourceModelConnection;
+
+    QString psdFileName;
+    QMap<QString, QPsdAbstractLayerItem::ExportHint> layerHints;
+    QMap<QString, QVariantMap> exportHints;
+};
+
+QPsdExporterTreeItemModel::Private::Private(const ::QPsdExporterTreeItemModel *model) : q(model)
+{
+}
+
+QPsdExporterTreeItemModel::Private::~Private()
+{
+}
+
+bool QPsdExporterTreeItemModel::Private::isValidIndex(const QModelIndex &index) const
+{
+    return index.isValid() && index.model() == q;
+}
+
+QPsdExporterTreeItemModel::QPsdExporterTreeItemModel(QObject *parent)
+    : QIdentityProxyModel(parent), d(new Private(this))
+{
+}
+
+QPsdExporterTreeItemModel::~QPsdExporterTreeItemModel()
+{
+}
+
+QHash<int, QByteArray> QPsdExporterTreeItemModel::roleNames() const
+{
+    auto roles = QAbstractItemModel::roleNames();
+    roles.insert(Roles::LayerIdRole, QByteArrayLiteral("LayerId"));
+    roles.insert(Roles::NameRole, QByteArrayLiteral("Name"));
+    roles.insert(Roles::LayerRecordObjectRole, QByteArrayLiteral("LayerRecordObject"));
+    roles.insert(Roles::FolderTypeRole, QByteArrayLiteral("FolderType"));
+    roles.insert(Roles::GroupIndexesRole, QByteArrayLiteral("GroupIndexes"));
+    roles.insert(Roles::ClippingMaskIndexRole, QByteArrayLiteral("ClippingMaskIndex"));
+    roles.insert(Roles::LayerItemObjectRole, QByteArrayLiteral("LayerItemObject"));
+    roles.insert(Roles::LayerHintRole, QByteArrayLiteral("LayerHint"));
+
+    return roles;
+}
+
+QVariant QPsdExporterTreeItemModel::data(const QModelIndex &index, int role) const
+{
+    if (!d->isValidIndex(index))
+        return QVariant();
+
+    switch (role) {
+    case Roles::LayerHintRole:
+        return QVariant::fromValue(layerHint(index));
+    default:
+        return sourceModel()->data(mapToSource(index), role);
+    }
+}
+
+void QPsdExporterTreeItemModel::fromParser(const QPsdParser &parser,
+    const QMap<QString, QPsdAbstractLayerItem::ExportHint> layerHints,
+    const QMap<QString, QVariantMap> exportHints)
+{
+    d->layerHints = layerHints;
+    d->exportHints = exportHints;
+
+    fromParser(parser);
+}
+
+void QPsdExporterTreeItemModel::fromParser(const QPsdParser &parser)
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return;
+    }
+
+    parentModel->fromParser(parser);
+}
+
+QSize QPsdExporterTreeItemModel::size() const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->size();
+}
+
+QVariantMap QPsdExporterTreeItemModel::exportHint(const QString &exporterKey) const
+{
+    return d->exportHints.value(exporterKey);
+}
+
+void QPsdExporterTreeItemModel::setExportHint(const QString &exporterKey, const QVariantMap exportHint)
+{
+    d->exportHints.insert(exporterKey, exportHint);
+}
+
+qint32 QPsdExporterTreeItemModel::layerId(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->layerId(mapToSource(index));
+}
+
+QString QPsdExporterTreeItemModel::layerName(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->layerName(mapToSource(index));
+}
+
+const QPsdLayerRecord *QPsdExporterTreeItemModel::layerRecord(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->layerRecord(mapToSource(index));
+}
+
+enum QPsdAbstractLayerTreeItemModel::FolderType QPsdExporterTreeItemModel::folderType(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->folderType(mapToSource(index));
+}
+
+QList<QPersistentModelIndex> QPsdExporterTreeItemModel::groupIndexes(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->groupIndexes(mapToSource(index));
+}
+
+QPersistentModelIndex QPsdExporterTreeItemModel::clippingMaskIndex(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->clippingMaskIndex(mapToSource(index));
+}
+
+const QPsdAbstractLayerItem *QPsdExporterTreeItemModel::layerItem(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->layerItem(mapToSource(index));
+}
+
+QPsdAbstractLayerItem::ExportHint QPsdExporterTreeItemModel::layerHint(const QModelIndex &index) const
+{
+    QPsdGuiAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdGuiAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return d->layerHints.value(QString::number(layerId(index)));
+}
+
+void QPsdExporterTreeItemModel::setLayerHint(const QModelIndex &index, const QPsdAbstractLayerItem::ExportHint layerHint)
+{
+    d->layerHints.insert(QString::number(layerId(index)), layerHint);
+}
+
+QMap<QString, QPsdAbstractLayerItem::ExportHint> QPsdExporterTreeItemModel::layerHints() const
+{
+    return d->layerHints;
+}
+
+QMap<QString, QVariantMap> QPsdExporterTreeItemModel::exportHints() const
+{
+    return d->exportHints;
+}
+
+QT_END_NAMESPACE

--- a/src/psdgui/qpsdexportertreeitemmodel.h
+++ b/src/psdgui/qpsdexportertreeitemmodel.h
@@ -53,7 +53,7 @@ public:
     void fromParser(const QPsdParser &parser) override;
     QSize size() const override;
     QVariantMap exportHint(const QString& exporterKey) const override;
-    void setExportHint(const QString& exporterKey, const QVariantMap exportHint);
+    void setExportHint(const QString& exporterKey, const QVariantMap exportHint) override;
 
     qint32 layerId(const QModelIndex &index) const override;
     QString layerName(const QModelIndex &index) const override;

--- a/src/psdgui/qpsdexportertreeitemmodel.h
+++ b/src/psdgui/qpsdexportertreeitemmodel.h
@@ -1,0 +1,77 @@
+// Copyright (C) 2024 Signal Slot Inc.
+// SPDX-License-Identifier: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#ifndef QPSDEXPORTERTREEITEMMODEL_H
+#define QPSDEXPORTERTREEITEMMODEL_H
+
+#include <QtPsdGui/qpsdabstractlayeritem.h>
+#include <QtPsdGui/QPsdGuiLayerTreeItemModel>
+
+#include <QtPsdCore/QPsdLayerTreeItemModel>
+
+#include <QIdentityProxyModel>
+
+QT_BEGIN_NAMESPACE
+
+class Q_PSDGUI_EXPORT QPsdExporterAbstractTreeItemModel : public QPsdGuiAbstractLayerTreeItemModel {
+public:
+    virtual QVariantMap exportHint(const QString& exporterKey) const = 0;
+    virtual void setExportHint(const QString& exporterKey, const QVariantMap exportHint) = 0;
+
+    virtual QPsdAbstractLayerItem::ExportHint layerHint(const QModelIndex &index) const = 0;
+    virtual void setLayerHint(const QModelIndex &index, const QPsdAbstractLayerItem::ExportHint layerHint) = 0;
+
+    virtual QMap<QString, QPsdAbstractLayerItem::ExportHint> layerHints() const = 0;
+    virtual QMap<QString, QVariantMap> exportHints() const = 0;
+};
+
+class Q_PSDGUI_EXPORT QPsdExporterTreeItemModel : public QIdentityProxyModel, public QPsdExporterAbstractTreeItemModel
+{
+    Q_OBJECT
+public:
+    enum Roles {
+        LayerIdRole = QPsdGuiLayerTreeItemModel::Roles::LayerIdRole,
+        NameRole = QPsdGuiLayerTreeItemModel::Roles::NameRole,
+        LayerRecordObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerRecordObjectRole,
+        FolderTypeRole = QPsdGuiLayerTreeItemModel::Roles::FolderTypeRole,
+        GroupIndexesRole = QPsdGuiLayerTreeItemModel::Roles::GroupIndexesRole,
+        ClippingMaskIndexRole = QPsdGuiLayerTreeItemModel::Roles::ClippingMaskIndexRole,
+        LayerItemObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole,
+        LayerHintRole,
+    };
+
+    explicit QPsdExporterTreeItemModel(QObject *parent = nullptr);
+    ~QPsdExporterTreeItemModel();
+
+    QHash<int, QByteArray> roleNames() const override;
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    void fromParser(const QPsdParser &parser,
+        const QMap<QString, QPsdAbstractLayerItem::ExportHint> layerHints,
+        const QMap<QString, QVariantMap> exportHints);
+    void fromParser(const QPsdParser &parser) override;
+    QSize size() const override;
+    QVariantMap exportHint(const QString& exporterKey) const override;
+    void setExportHint(const QString& exporterKey, const QVariantMap exportHint);
+
+    qint32 layerId(const QModelIndex &index) const override;
+    QString layerName(const QModelIndex &index) const override;
+    const QPsdLayerRecord *layerRecord(const QModelIndex &index) const override;
+    enum FolderType folderType(const QModelIndex &index) const override;
+    QList<QPersistentModelIndex> groupIndexes(const QModelIndex &index) const override;
+    QPersistentModelIndex clippingMaskIndex(const QModelIndex &index) const override;
+    const QPsdAbstractLayerItem *layerItem(const QModelIndex &index) const override;
+    QPsdAbstractLayerItem::ExportHint layerHint(const QModelIndex &index) const override;
+    void setLayerHint(const QModelIndex &index, const QPsdAbstractLayerItem::ExportHint layerHint) override;
+    QMap<QString, QPsdAbstractLayerItem::ExportHint> layerHints() const override;
+    QMap<QString, QVariantMap> exportHints() const override;
+
+private:
+    class Private;
+    QScopedPointer<Private> d;
+};
+
+QT_END_NAMESPACE
+
+#endif // QPSDEXPORTERTREEITEMMODEL_H

--- a/src/psdgui/qpsdguilayertreeitemmodel.cpp
+++ b/src/psdgui/qpsdguilayertreeitemmodel.cpp
@@ -123,24 +123,24 @@ QVariant QPsdGuiLayerTreeItemModel::data(const QModelIndex &index, int role) con
 {
     switch (role) {
     case Roles::GroupIndexesRole: {
-        QList<QVariant> indexes = sourceModel()->data(index, role).toList();
+        QList<QVariant> indexes = sourceModel()->data(mapToSource(index), role).toList();
         QList<QVariant> result;
         for (const auto &i : indexes) {
-            QModelIndex index = i.value<QPersistentModelIndex>();
-            result.append(QVariant::fromValue(QPersistentModelIndex(mapFromSource(index))));
+            QModelIndex sourceIndex = i.value<QPersistentModelIndex>();
+            result.append(QVariant::fromValue(QPersistentModelIndex(mapFromSource(sourceIndex))));
         }
         return QVariant(result); }
     case Roles::ClippingMaskIndexRole: {
-        QPersistentModelIndex maskIndex = sourceModel()->data(index, role).value<QPersistentModelIndex>();
+        QPersistentModelIndex maskIndex = sourceModel()->data(mapToSource(index), role).value<QPersistentModelIndex>();
         return QVariant::fromValue(mapFromSource(maskIndex)); }
     case Roles::LayerItemObjectRole:
         return QVariant::fromValue(
             d->layerItemObject(
-                sourceModel()->data(index, QPsdLayerTreeItemModel::Roles::LayerRecordObjectRole).value<const QPsdLayerRecord *>(),
-                sourceModel()->data(index, QPsdLayerTreeItemModel::Roles::FolderTypeRole).value<enum QPsdLayerTreeItemModel::FolderType>()
+                sourceModel()->data(mapToSource(index), QPsdLayerTreeItemModel::Roles::LayerRecordObjectRole).value<const QPsdLayerRecord *>(),
+                sourceModel()->data(mapToSource(index), QPsdLayerTreeItemModel::Roles::FolderTypeRole).value<enum QPsdLayerTreeItemModel::FolderType>()
                 ));
     default:
-        return sourceModel()->data(index, role);
+        return sourceModel()->data(mapToSource(index), role);
     }
 }
 

--- a/src/psdgui/qpsdguilayertreeitemmodel.cpp
+++ b/src/psdgui/qpsdguilayertreeitemmodel.cpp
@@ -190,4 +190,74 @@ QSize QPsdGuiLayerTreeItemModel::size() const
     return parentModel->size();
 }
 
+qint32 QPsdGuiLayerTreeItemModel::layerId(const QModelIndex &index) const
+{
+    QPsdAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->layerId(mapToSource(index));
+}
+
+QString QPsdGuiLayerTreeItemModel::layerName(const QModelIndex &index) const
+{
+    QPsdAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->layerName(mapToSource(index));
+}
+
+const QPsdLayerRecord *QPsdGuiLayerTreeItemModel::layerRecord(const QModelIndex &index) const
+{
+    QPsdAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->layerRecord(mapToSource(index));
+}
+
+enum QPsdAbstractLayerTreeItemModel::FolderType QPsdGuiLayerTreeItemModel::folderType(const QModelIndex &index) const
+{
+    QPsdAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->folderType(mapToSource(index));
+}
+
+QList<QPersistentModelIndex> QPsdGuiLayerTreeItemModel::groupIndexes(const QModelIndex &index) const
+{
+    QPsdAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->groupIndexes(mapToSource(index));
+}
+
+QPersistentModelIndex QPsdGuiLayerTreeItemModel::clippingMaskIndex(const QModelIndex &index) const
+{
+    QPsdAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return parentModel->clippingMaskIndex(mapToSource(index));
+}
+
+const QPsdAbstractLayerItem *QPsdGuiLayerTreeItemModel::layerItem(const QModelIndex &index) const
+{
+    QPsdAbstractLayerTreeItemModel *parentModel = dynamic_cast<QPsdAbstractLayerTreeItemModel *>(sourceModel());
+    if (parentModel == nullptr) {
+        return {};
+    }
+
+    return d->layerItemObject(parentModel->layerRecord(index), parentModel->folderType(index));
+}
+
 QT_END_NAMESPACE

--- a/src/psdgui/qpsdguilayertreeitemmodel.h
+++ b/src/psdgui/qpsdguilayertreeitemmodel.h
@@ -12,7 +12,7 @@
 
 QT_BEGIN_NAMESPACE
 
-class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QIdentityProxyModel
+class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QIdentityProxyModel, public QPsdAbstractLayerTreeItemModel
 {
     Q_OBJECT
 public:
@@ -37,8 +37,8 @@ public:
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-    void fromParser(const QPsdParser &parser);
-    QSize size() const;
+    void fromParser(const QPsdParser &parser) override;
+    QSize size() const override;
 
 private:
     class Private;

--- a/src/psdgui/qpsdguilayertreeitemmodel.h
+++ b/src/psdgui/qpsdguilayertreeitemmodel.h
@@ -12,7 +12,12 @@
 
 QT_BEGIN_NAMESPACE
 
-class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QIdentityProxyModel, public QPsdAbstractLayerTreeItemModel
+class Q_PSDGUI_EXPORT QPsdGuiAbstractLayerTreeItemModel : public QPsdAbstractLayerTreeItemModel {
+public:
+    virtual const QPsdAbstractLayerItem *layerItem(const QModelIndex &index) const = 0;
+};
+
+class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QIdentityProxyModel, public QPsdGuiAbstractLayerTreeItemModel
 {
     Q_OBJECT
 public:
@@ -39,6 +44,14 @@ public:
 
     void fromParser(const QPsdParser &parser) override;
     QSize size() const override;
+
+    qint32 layerId(const QModelIndex &index) const override;
+    QString layerName(const QModelIndex &index) const override;
+    const QPsdLayerRecord *layerRecord(const QModelIndex &index) const override;
+    enum FolderType folderType(const QModelIndex &index) const override;
+    QList<QPersistentModelIndex> groupIndexes(const QModelIndex &index) const override;
+    QPersistentModelIndex clippingMaskIndex(const QModelIndex &index) const override;
+    const QPsdAbstractLayerItem *layerItem(const QModelIndex &index) const override;
 
 private:
     class Private;


### PR DESCRIPTION
エクスポート時のヒント情報を(ItemModel の範囲では) exampleアプリ側の PsdTreeItemModel で持っていたのを QPsdExporterTreeItemModel クラスに持てるようにしました。あと、これまで data() で QVariant でデータを取得する実装しかしていなかったのですが、通常のクラスのオブジェクトを返すメソッドを実装して、data() 内で QVariant に変換して返すようにしています

確認事項というか懸念点は思いつく範囲では以下のようなことがありますが一度みてもらえますでしょうか

- 純粋仮想関数だけを持つクラスを(Java の interface の代わりに) 多重継承するようにしています
  - QPsdLayerTreeItemModel は QAbstractItemModel と QPsdAbstractLayerTreeItemModel を継承
  - QPsdGuiLayerTreeItemModel は QIdentityProxyModel と QPsdGuiAbstractLayerTreeItemModel を継承
    - QPsdGuiAbstractLayerTreeItemModel が QPsdAbstractLayerTreeItemModel を継承しているので、QPsdGuiLayerTreeItemModel も QPsdLayerTreeItemModel も同じインタフェースを持っていることを保証する
- ひとまず psdgui/ モジュールに置いています
 