### PR TITLE
fix QPsdGuiLayerTreeItemModel to inherit from QPsdLayerTreeItemModel

### DIFF
--- a/examples/psdcore/app/psdtreeitemmodel.h
+++ b/examples/psdcore/app/psdtreeitemmodel.h
@@ -18,12 +18,12 @@ class PsdTreeItemModel : public QIdentityProxyModel
 
 public:
     enum Roles {
-        LayerIdRole = QPsdGuiLayerTreeItemModel::Roles::LayerIdRole,
-        NameRole = QPsdGuiLayerTreeItemModel::Roles::NameRole,
-        LayerRecordObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerRecordObjectRole,
-        FolderTypeRole = QPsdGuiLayerTreeItemModel::Roles::FolderTypeRole,
-        GroupIndexesRole = QPsdGuiLayerTreeItemModel::Roles::GroupIndexesRole,
-        ClippingMaskIndexRole = QPsdGuiLayerTreeItemModel::Roles::ClippingMaskIndexRole,
+        LayerIdRole = QPsdLayerTreeItemModel::Roles::LayerIdRole,
+        NameRole = QPsdLayerTreeItemModel::Roles::NameRole,
+        LayerRecordObjectRole = QPsdLayerTreeItemModel::Roles::LayerRecordObjectRole,
+        FolderTypeRole = QPsdLayerTreeItemModel::Roles::FolderTypeRole,
+        GroupIndexesRole = QPsdLayerTreeItemModel::Roles::GroupIndexesRole,
+        ClippingMaskIndexRole = QPsdLayerTreeItemModel::Roles::ClippingMaskIndexRole,
         LayerItemObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole,
         VisibleRole,
         ExportIdRole,

--- a/examples/psdcore/app/psdtreeitemmodel.h
+++ b/examples/psdcore/app/psdtreeitemmodel.h
@@ -18,12 +18,12 @@ class PsdTreeItemModel : public QIdentityProxyModel
 
 public:
     enum Roles {
-        LayerIdRole = QPsdLayerTreeItemModel::Roles::LayerIdRole,
-        NameRole = QPsdLayerTreeItemModel::Roles::NameRole,
-        LayerRecordObjectRole = QPsdLayerTreeItemModel::Roles::LayerRecordObjectRole,
-        FolderTypeRole = QPsdLayerTreeItemModel::Roles::FolderTypeRole,
-        GroupIndexesRole = QPsdLayerTreeItemModel::Roles::GroupIndexesRole,
-        ClippingMaskIndexRole = QPsdLayerTreeItemModel::Roles::ClippingMaskIndexRole,
+        LayerIdRole = QPsdGuiLayerTreeItemModel::LayerIdRole,
+        NameRole = QPsdGuiLayerTreeItemModel::NameRole,
+        LayerRecordObjectRole = QPsdGuiLayerTreeItemModel::LayerRecordObjectRole,
+        FolderTypeRole = QPsdGuiLayerTreeItemModel::FolderTypeRole,
+        GroupIndexesRole = QPsdGuiLayerTreeItemModel::GroupIndexesRole,
+        ClippingMaskIndexRole = QPsdGuiLayerTreeItemModel::ClippingMaskIndexRole,
         LayerItemObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole,
         VisibleRole,
         ExportIdRole,

--- a/src/psdgui/qpsdguilayertreeitemmodel.h
+++ b/src/psdgui/qpsdguilayertreeitemmodel.h
@@ -15,17 +15,7 @@ class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QPsdLayerTreeItemModel
     Q_OBJECT
 public:
     enum Roles {
-        LayerIdRole = QPsdLayerTreeItemModel::Roles::LayerIdRole,
-        NameRole = QPsdLayerTreeItemModel::Roles::NameRole,
-        LayerRecordObjectRole = QPsdLayerTreeItemModel::Roles::LayerRecordObjectRole,
-        FolderTypeRole = QPsdLayerTreeItemModel::Roles::FolderTypeRole,
-        GroupIndexesRole = QPsdLayerTreeItemModel::Roles::GroupIndexesRole,
-        ClippingMaskIndexRole = QPsdLayerTreeItemModel::Roles::ClippingMaskIndexRole,
-        LayerItemObjectRole,
-    };
-    enum Column {
-        LayerId = QPsdLayerTreeItemModel::LayerId,
-        Name = QPsdLayerTreeItemModel::Name,
+        LayerItemObjectRole = QPsdLayerTreeItemModel::Roles::ClippingMaskIndexRole + 1
     };
 
     explicit QPsdGuiLayerTreeItemModel(QObject *parent = nullptr);

--- a/src/psdgui/qpsdguilayertreeitemmodel.h
+++ b/src/psdgui/qpsdguilayertreeitemmodel.h
@@ -8,11 +8,9 @@
 
 #include <QtPsdCore/QPsdLayerTreeItemModel>
 
-#include <QIdentityProxyModel>
-
 QT_BEGIN_NAMESPACE
 
-class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QIdentityProxyModel
+class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QPsdLayerTreeItemModel
 {
     Q_OBJECT
 public:
@@ -38,7 +36,6 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
     void fromParser(const QPsdParser &parser);
-    QSize size() const;
 
 private:
     class Private;

--- a/src/psdgui/qpsdguilayertreeitemmodel.h
+++ b/src/psdgui/qpsdguilayertreeitemmodel.h
@@ -15,7 +15,7 @@ class Q_PSDGUI_EXPORT QPsdGuiLayerTreeItemModel : public QPsdLayerTreeItemModel
     Q_OBJECT
 public:
     enum Roles {
-        LayerItemObjectRole = QPsdLayerTreeItemModel::Roles::ClippingMaskIndexRole + 1
+        LayerItemObjectRole = ClippingMaskIndexRole + 1
     };
 
     explicit QPsdGuiLayerTreeItemModel(QObject *parent = nullptr);


### PR DESCRIPTION
QPsdGuiLayerTreeItemModel が QPsdLayerTreeItemModel を継承するように変更しました