### PR TITLE
PsdTreeItemModel を QPsdGuiLayerTreeItemModel のサブクラスに修正

### DIFF
--- a/src/apps/psdexporter/psdtreeitemmodel.cpp
+++ b/src/apps/psdexporter/psdtreeitemmodel.cpp
@@ -6,6 +6,7 @@
 #include <QtPsdCore/QPsdParser>
 #include <QtPsdGui/QPsdFolderLayerItem>
 #include <QtPsdGui/QPsdGuiLayerTreeItemModel>
+#include <QtPsdGui/QPsdLayerTree>
 
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
@@ -23,7 +24,6 @@ public:
     QFileInfo hintFileInfo(const QString &psdFileName) const;
     QJsonDocument loadHint(const QString &hintFileName);
 
-    QPsdAbstractLayerItem *node(const QModelIndex &index) const;
     bool isValidIndex(const QModelIndex &index) const;
 
     bool isVisible(const QModelIndex &index);
@@ -34,7 +34,6 @@ public:
     QFileInfo fileInfo;
     QString errorMessage;
 
-    QPsdGuiLayerTreeItemModel parentModel;
     QPsdFolderLayerItem *root = nullptr;
 
     QMap<QString, QPsdAbstractLayerItem::ExportHint> layerHints;
@@ -82,11 +81,6 @@ QJsonDocument PsdTreeItemModel::Private::loadHint(const QString &hintFileName)
     return {};
 }
 
-QPsdAbstractLayerItem *PsdTreeItemModel::Private::node(const QModelIndex &index) const
-{
-    return parentModel.data(q->mapToSource(index), QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole).value<QPsdAbstractLayerItem*>();
-}
-
 bool PsdTreeItemModel::Private::isValidIndex(const QModelIndex &index) const
 {
     return index.isValid() && index.model() == q;
@@ -98,14 +92,14 @@ bool PsdTreeItemModel::Private::isVisible(const QModelIndex &index)
         return false;
     }
 
-    const auto *node = this->node(index);
-    if (node == nullptr) {
+    const auto *item = q->layerItem(index);
+    if (item == nullptr) {
         return false;
     }
-    QString idstr = QString::number(node->id());
+    QString idstr = QString::number(item->id());
 
     if (!visibleMap.contains(idstr)) {
-        visibleMap.insert(idstr, node->isVisible());
+        visibleMap.insert(idstr, item->isVisible());
     }
 
     return visibleMap.value(idstr);
@@ -117,17 +111,17 @@ void PsdTreeItemModel::Private::setVisible(const QModelIndex &index, bool visibl
         return;
     }
 
-    const auto *node = this->node(index);
-    if (node == nullptr) {
+    const auto *item = q->layerItem(index);
+    if (item == nullptr) {
         return;
     }
-    QString idstr = QString::number(node->id());
+    QString idstr = QString::number(item->id());
 
     visibleMap.insert(idstr, visible);
 }
 
 PsdTreeItemModel::PsdTreeItemModel(QObject *parent)
-    : QIdentityProxyModel(parent), d(new Private(this))
+    : QPsdGuiLayerTreeItemModel(parent), d(new Private(this))
 {
 }
 
@@ -159,14 +153,7 @@ QVariant PsdTreeItemModel::headerData(int section, Qt::Orientation orientation, 
 
 QHash<int, QByteArray> PsdTreeItemModel::roleNames() const
 {
-    auto roles = QAbstractItemModel::roleNames();
-    roles.insert(Roles::LayerIdRole, QByteArrayLiteral("LayerId"));
-    roles.insert(Roles::NameRole, QByteArrayLiteral("Name"));
-    roles.insert(Roles::LayerRecordObjectRole, QByteArrayLiteral("LayerRecordObject"));
-    roles.insert(Roles::FolderTypeRole, QByteArrayLiteral("FolderType"));
-    roles.insert(Roles::GroupIndexesRole, QByteArrayLiteral("GroupIndexes"));
-    roles.insert(Roles::ClippingMaskIndexRole, QByteArrayLiteral("ClippingMaskIndex"));
-    roles.insert(Roles::LayerItemObjectRole, QByteArrayLiteral("LayerItemObject"));
+    auto roles = QPsdGuiLayerTreeItemModel::roleNames();
     roles.insert(Roles::VisibleRole, QByteArrayLiteral("Visible"));
     roles.insert(Roles::ExportIdRole, QByteArrayLiteral("ExportId"));
 
@@ -184,13 +171,13 @@ QVariant PsdTreeItemModel::data(const QModelIndex &index, int role) const
     if (!d->isValidIndex(index))
         return QVariant();
 
-    const QPsdAbstractLayerItem *node = d->node(index);
-    const QPsdAbstractLayerItem::ExportHint exportHint = node->exportHint();
+    const QPsdAbstractLayerItem *item = layerItem(index);
+    const QPsdAbstractLayerItem::ExportHint exportHint = item->exportHint();
     switch (role) {
     case Qt::DisplayRole:
         switch (index.column()) {
         case Column::Name:
-            return node->name();
+            return item->name();
         case Column::Export:
             return exportHint.id;
         default:
@@ -222,7 +209,7 @@ QVariant PsdTreeItemModel::data(const QModelIndex &index, int role) const
         }
         break;
     case Qt::BackgroundRole: {
-        QColor color = node->color();
+        QColor color = item->color();
         int h, s, l, a;
         color.getHsl(&h, &s, &l, &a);
         color.setHsl(h, 128, 128, 128 * a / 255);
@@ -230,34 +217,17 @@ QVariant PsdTreeItemModel::data(const QModelIndex &index, int role) const
     case Qt::DecorationRole:
         switch (index.column()) {
         case Column::Name:
-            return QIcon(QPixmap::fromImage(node->image()));
+            return QIcon(QPixmap::fromImage(item->image()));
         default:
             break;
         }
         break;
-    case Roles::NameRole:
-        return node->name();
-    case Roles::LayerIdRole:
-        return node->id();
     case Roles::VisibleRole:
-        return d->isVisible(index);
+        return isVisible(index);
     case Roles::ExportIdRole:
         return exportHint.id;
-     case Roles::GroupIndexesRole: {
-        QList<QVariant> indexes = sourceModel()->data(index, role).toList();
-        QList<QVariant> result;
-        for (const auto &i : indexes) {
-            QModelIndex index = i.value<QPersistentModelIndex>();
-            result.append(QVariant::fromValue(QPersistentModelIndex(mapFromSource(index))));
-        }
-        return QVariant(result); }
-    case Roles::ClippingMaskIndexRole: {
-        QPersistentModelIndex maskIndex = sourceModel()->data(index, role).value<QPersistentModelIndex>();
-        return QVariant::fromValue(mapFromSource(maskIndex)); }
-    case Roles::LayerItemObjectRole:
-        return QVariant::fromValue(node);
     default:
-        return sourceModel()->data(index, role);
+        return QPsdGuiLayerTreeItemModel::data(index, role);
     }
 
     return {};
@@ -275,10 +245,10 @@ bool PsdTreeItemModel::setData(const QModelIndex &index, const QVariant &value, 
         }
         break;
     case Column::Export: {
-        const QPsdAbstractLayerItem *node = d->node(index);
-        QPsdAbstractLayerItem::ExportHint exportHint = node->exportHint();
+        const QPsdAbstractLayerItem *item = layerItem(index);
+        QPsdAbstractLayerItem::ExportHint exportHint = item->exportHint();
         exportHint.id = value.toString();
-        node->setExportHint(exportHint);
+        item->setExportHint(exportHint);
 
         emit dataChanged(index, index);
         return true; }
@@ -304,6 +274,16 @@ Qt::ItemFlags PsdTreeItemModel::flags(const QModelIndex &index) const
     return flags;
 }
 
+bool PsdTreeItemModel::isVisible(const QModelIndex &index) const
+{
+    return d->isVisible(index);
+}
+
+QString PsdTreeItemModel::exportId(const QModelIndex &index) const
+{
+
+}
+
 QFileInfo PsdTreeItemModel::fileInfo() const
 {
     return d->fileInfo;
@@ -317,11 +297,6 @@ QString PsdTreeItemModel::fileName() const
 QString PsdTreeItemModel::errorMessage() const
 {
     return d->errorMessage;
-}
-
-QSize PsdTreeItemModel::size() const
-{
-    return d->parentModel.size();
 }
 
 const QPsdFolderLayerItem *PsdTreeItemModel::layerTree() const
@@ -352,8 +327,7 @@ void PsdTreeItemModel::load(const QString &fileName)
     QPsdParser parser;
     parser.load(fileName);
 
-    d->parentModel.fromParser(parser);
-    setSourceModel(&d->parentModel);
+    fromParser(parser);
 
     const auto header = parser.fileHeader();
     if (!header.errorString().isEmpty()) {
@@ -392,7 +366,7 @@ void PsdTreeItemModel::load(const QString &fileName)
     traverseTree = [&](const QModelIndex &parent) {
         for (int row = 0; row < rowCount(parent); row++) {
             const QModelIndex childIndex = index(row, 0, parent);
-            const QPsdAbstractLayerItem *item = data(childIndex, Roles::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
+            const QPsdAbstractLayerItem *item = layerItem(childIndex);
             const QString idstr = QString::number(item->id());
             QPsdAbstractLayerItem::ExportHint exportHint = d->layerHints.value(idstr);
             exportHint.visible = item->isVisible();
@@ -415,7 +389,7 @@ void PsdTreeItemModel::save()
     QJsonObject layerHints;
     std::function<void(const QModelIndex &)> traverse = [&](const QModelIndex &index) {
         if (index.isValid()) {
-            const auto layer = data(index, PsdTreeItemModel::Roles::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
+            const auto layer = layerItem(index);
             const auto lyid = layer->id();
             const auto idstr = QString::number(lyid);
 

--- a/src/apps/psdexporter/psdtreeitemmodel.cpp
+++ b/src/apps/psdexporter/psdtreeitemmodel.cpp
@@ -281,7 +281,10 @@ bool PsdTreeItemModel::isVisible(const QModelIndex &index) const
 
 QString PsdTreeItemModel::exportId(const QModelIndex &index) const
 {
+    const QPsdAbstractLayerItem *item = layerItem(index);
+    QPsdAbstractLayerItem::ExportHint exportHint = item->exportHint();
 
+    return exportHint.id;
 }
 
 QFileInfo PsdTreeItemModel::fileInfo() const

--- a/src/apps/psdexporter/psdtreeitemmodel.h
+++ b/src/apps/psdexporter/psdtreeitemmodel.h
@@ -4,13 +4,11 @@
 #ifndef PSDTREEITEMMODEL_H
 #define PSDTREEITEMMODEL_H
 
-#include <QtPsdGui/QPsdLayerTree>
 #include <QtPsdGui/QPsdGuiLayerTreeItemModel>
 
-#include <QIdentityProxyModel>
 #include <QFileInfo>
 
-class PsdTreeItemModel : public QIdentityProxyModel
+class PsdTreeItemModel : public QPsdGuiLayerTreeItemModel
 {
     Q_OBJECT
 
@@ -18,14 +16,7 @@ class PsdTreeItemModel : public QIdentityProxyModel
 
 public:
     enum Roles {
-        LayerIdRole = QPsdGuiLayerTreeItemModel::LayerIdRole,
-        NameRole = QPsdGuiLayerTreeItemModel::NameRole,
-        LayerRecordObjectRole = QPsdGuiLayerTreeItemModel::LayerRecordObjectRole,
-        FolderTypeRole = QPsdGuiLayerTreeItemModel::FolderTypeRole,
-        GroupIndexesRole = QPsdGuiLayerTreeItemModel::GroupIndexesRole,
-        ClippingMaskIndexRole = QPsdGuiLayerTreeItemModel::ClippingMaskIndexRole,
-        LayerItemObjectRole = QPsdGuiLayerTreeItemModel::Roles::LayerItemObjectRole,
-        VisibleRole,
+        VisibleRole = QPsdGuiLayerTreeItemModel::LayerItemObjectRole + 1,
         ExportIdRole,
     };
     enum Column {
@@ -50,10 +41,12 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
 
+    bool isVisible(const QModelIndex &index) const;
+    QString exportId(const QModelIndex &index) const;
+
     QFileInfo fileInfo() const;
     QString fileName() const;
     QString errorMessage() const;
-    QSize size() const;
 
     const QPsdFolderLayerItem *layerTree() const;
     QVariantMap exportHint(const QString& exporterKey) const;

--- a/src/apps/psdexporter/psdview.cpp
+++ b/src/apps/psdexporter/psdview.cpp
@@ -86,11 +86,11 @@ void PsdView::reset()
     resize(d->model->size());
     std::function<void(const QModelIndex, QWidget *)> traverseTree = [&](const QModelIndex index, QWidget *parent) {
         if (index.isValid()) {
-            const QPsdAbstractLayerItem *layer = d->model->data(index, PsdTreeItemModel::Roles::LayerItemObjectRole).value<const QPsdAbstractLayerItem*>();            
+            const QPsdAbstractLayerItem *layer = d->model->data(index, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem*>();
             const QModelIndex maskIndex = d->model->data(index, PsdTreeItemModel::ClippingMaskIndexRole).toModelIndex();
             const QPsdAbstractLayerItem *mask = nullptr;
             if (maskIndex.isValid()) {
-                mask = d->model->data(maskIndex, PsdTreeItemModel::Roles::LayerItemObjectRole).value<const QPsdAbstractLayerItem*>();
+                mask = d->model->data(maskIndex, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem*>();
             }
             const QVariantList groupVariantList = d->model->data(index, PsdTreeItemModel::GroupIndexesRole).toList();
             QMap<quint32, QString> groupMap;

--- a/src/apps/psdexporter/psdview.cpp
+++ b/src/apps/psdexporter/psdview.cpp
@@ -86,18 +86,17 @@ void PsdView::reset()
     resize(d->model->size());
     std::function<void(const QModelIndex, QWidget *)> traverseTree = [&](const QModelIndex index, QWidget *parent) {
         if (index.isValid()) {
-            const QPsdAbstractLayerItem *layer = d->model->data(index, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem*>();
-            const QModelIndex maskIndex = d->model->data(index, PsdTreeItemModel::ClippingMaskIndexRole).toModelIndex();
+            const QPsdAbstractLayerItem *layer = d->model->layerItem(index);
+            const QModelIndex maskIndex = d->model->clippingMaskIndex(index);
             const QPsdAbstractLayerItem *mask = nullptr;
             if (maskIndex.isValid()) {
-                mask = d->model->data(maskIndex, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem*>();
+                mask = d->model->layerItem(maskIndex);
             }
-            const QVariantList groupVariantList = d->model->data(index, PsdTreeItemModel::GroupIndexesRole).toList();
+            const QList<QPersistentModelIndex> groupIndexesList = d->model->groupIndexes(index);
             QMap<quint32, QString> groupMap;
-            for (auto &v : groupVariantList) {
-                QModelIndex modelIndex = v.toModelIndex();
-                quint32 id = d->model->data(modelIndex, PsdTreeItemModel::LayerIdRole).toUInt();
-                QString name = d->model->data(modelIndex, PsdTreeItemModel::NameRole).toString();
+            for (auto &groupIndex : groupIndexesList) {
+                quint32 id = d->model->layerId(groupIndex);
+                QString name = d->model->layerName(groupIndex);
                 groupMap.insert(id, name);
             }
 

--- a/src/apps/psdexporter/psdwidget.cpp
+++ b/src/apps/psdexporter/psdwidget.cpp
@@ -40,16 +40,18 @@ PsdWidget::Private::Private(::PsdWidget *parent)
     treeView->setModel(&model);
 
     connect(&model, &PsdTreeItemModel::dataChanged, q, [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles) {
-        const auto *model = topLeft.model();
-        for (int r = topLeft.row(); r <= bottomRight.row(); r++) {
-            for (int c = topLeft.column(); c <= bottomRight.column(); c++) {
-                QModelIndex index = topLeft.sibling(r, c);
-                if (roles.empty() || roles.contains(Qt::CheckStateRole)) {
-                    if (c == PsdTreeItemModel::Column::Visible) {
-                        psdView->setItemVisible(model->data(index, PsdTreeItemModel::LayerIdRole).toInt(), model->data(index, PsdTreeItemModel::Roles::VisibleRole).toBool());
-                    } else {
-                        q->setWindowModified(true);
-                        q->setWindowTitle(windowTitle);
+        const auto *model = dynamic_cast<const PsdTreeItemModel *>(topLeft.model());
+        if (model) {
+            for (int r = topLeft.row(); r <= bottomRight.row(); r++) {
+                for (int c = topLeft.column(); c <= bottomRight.column(); c++) {
+                    QModelIndex index = topLeft.sibling(r, c);
+                    if (roles.empty() || roles.contains(Qt::CheckStateRole)) {
+                        if (c == PsdTreeItemModel::Column::Visible) {
+                            psdView->setItemVisible(model->layerId(index), model->isVisible(index));
+                        } else {
+                            q->setWindowModified(true);
+                            q->setWindowTitle(windowTitle);
+                        }
                     }
                 }
             }
@@ -57,13 +59,19 @@ PsdWidget::Private::Private(::PsdWidget *parent)
     });
 
     connect(treeView, &QTreeView::expanded, q, [this](const QModelIndex &index) {
-        const auto lyid = index.model()->data(index, PsdTreeItemModel::LayerIdRole).toInt();
-        settings.setValue(u"%1-x"_s.arg(lyid), true);
+        const auto *model = dynamic_cast<const PsdTreeItemModel *>(index.model());
+        if (model) {
+            const auto lyid = model->layerId(index);
+            settings.setValue(u"%1-x"_s.arg(lyid), true);
+        }
     });
 
     connect(treeView, &QTreeView::collapsed, q, [this](const QModelIndex &index) {
-        const auto lyid = index.model()->data(index, PsdTreeItemModel::LayerIdRole).toInt();
-        settings.setValue(u"%1-x"_s.arg(lyid), false);
+        const auto *model = dynamic_cast<const PsdTreeItemModel *>(index.model());
+        if (model) {
+            const auto lyid = model->layerId(index);
+            settings.setValue(u"%1-x"_s.arg(lyid), false);
+        }
     });
 
     connect(treeView->selectionModel(), &QItemSelectionModel::selectionChanged, q, [this]() {
@@ -258,15 +266,15 @@ void PsdWidget::Private::updateAttributes()
     QHash<QString, UniqueOrNot<Qt::CheckState>> itemProperties;
 
     for (const auto &row : rows) {
-        const auto item = model.data(row, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
-        const auto groupVariantList = model.data(row, PsdTreeItemModel::GroupIndexesRole).toList();
+        const auto *item = model.layerItem(row);
+        const auto groupVariantList = model.groupIndexes(row);
         const auto hint = item->exportHint();
         itemTypes.add(hint.type);
         itemWithTouch.add(hint.baseElement == QPsdAbstractLayerItem::ExportHint::TouchArea ? Qt::Checked : Qt::Unchecked);
         qDebug() << hint.baseElement << itemWithTouch.isUnique() << itemWithTouch.value();
         QList<QPersistentModelIndex> groupIndexList;
         for (auto &v : groupVariantList) {
-            groupIndexList.append(v.toModelIndex());
+            groupIndexList.append(v);
         }
         itemMergeGroup.add(groupIndexList);
         excludeFromMergeGroup.insert(row);
@@ -306,7 +314,7 @@ void PsdWidget::Private::updateAttributes()
             if (excludeFromMergeGroup.contains(item)) {
                 continue;
             }
-            QString name = model.data(item, PsdTreeItemModel::NameRole).toString();
+            QString name = model.layerName(item);
             merge->addItem(name);
         }
         merge->setCurrentIndex(-1);
@@ -384,7 +392,7 @@ void PsdWidget::Private::applyAttributes()
     }
 
     for (const auto &row : rows) {
-        const auto item = model.data(row, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
+        const auto *item = model.layerItem(row);
         auto hint = item->exportHint();
         if (type > -1)
             hint.type = static_cast<QPsdAbstractLayerItem::ExportHint::Type>(type);
@@ -451,7 +459,7 @@ void PsdWidget::load(const QString &fileName)
     std::function<void(const QModelIndex &index)> traverseTreeView;
     traverseTreeView = [&](const QModelIndex &index) {
         if (d->model.hasChildren(index)) {
-            const auto lyid = d->model.data(index, PsdTreeItemModel::LayerIdRole).toInt();
+            const auto lyid = d->model.layerId(index);
             d->treeView->setExpanded(index, d->settings.value(u"%1-x"_s.arg(lyid), false).toBool());
 
             for (int row = 0; row < d->model.rowCount(index); row++) {

--- a/src/apps/psdexporter/psdwidget.cpp
+++ b/src/apps/psdexporter/psdwidget.cpp
@@ -46,7 +46,7 @@ PsdWidget::Private::Private(::PsdWidget *parent)
                 QModelIndex index = topLeft.sibling(r, c);
                 if (roles.empty() || roles.contains(Qt::CheckStateRole)) {
                     if (c == PsdTreeItemModel::Column::Visible) {
-                        psdView->setItemVisible(model->data(index, PsdTreeItemModel::Roles::LayerIdRole).toInt(), model->data(index, PsdTreeItemModel::Roles::VisibleRole).toBool());
+                        psdView->setItemVisible(model->data(index, PsdTreeItemModel::LayerIdRole).toInt(), model->data(index, PsdTreeItemModel::Roles::VisibleRole).toBool());
                     } else {
                         q->setWindowModified(true);
                         q->setWindowTitle(windowTitle);
@@ -57,12 +57,12 @@ PsdWidget::Private::Private(::PsdWidget *parent)
     });
 
     connect(treeView, &QTreeView::expanded, q, [this](const QModelIndex &index) {
-        const auto lyid = index.model()->data(index, PsdTreeItemModel::Roles::LayerIdRole).toInt();
+        const auto lyid = index.model()->data(index, PsdTreeItemModel::LayerIdRole).toInt();
         settings.setValue(u"%1-x"_s.arg(lyid), true);
     });
 
     connect(treeView, &QTreeView::collapsed, q, [this](const QModelIndex &index) {
-        const auto lyid = index.model()->data(index, PsdTreeItemModel::Roles::LayerIdRole).toInt();
+        const auto lyid = index.model()->data(index, PsdTreeItemModel::LayerIdRole).toInt();
         settings.setValue(u"%1-x"_s.arg(lyid), false);
     });
 
@@ -258,8 +258,8 @@ void PsdWidget::Private::updateAttributes()
     QHash<QString, UniqueOrNot<Qt::CheckState>> itemProperties;
 
     for (const auto &row : rows) {
-        const auto item = model.data(row, PsdTreeItemModel::Roles::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
-        const auto groupVariantList = model.data(row, PsdTreeItemModel::Roles::GroupIndexesRole).toList();
+        const auto item = model.data(row, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
+        const auto groupVariantList = model.data(row, PsdTreeItemModel::GroupIndexesRole).toList();
         const auto hint = item->exportHint();
         itemTypes.add(hint.type);
         itemWithTouch.add(hint.baseElement == QPsdAbstractLayerItem::ExportHint::TouchArea ? Qt::Checked : Qt::Unchecked);
@@ -306,7 +306,7 @@ void PsdWidget::Private::updateAttributes()
             if (excludeFromMergeGroup.contains(item)) {
                 continue;
             }
-            QString name = model.data(item, PsdTreeItemModel::Roles::NameRole).toString();
+            QString name = model.data(item, PsdTreeItemModel::NameRole).toString();
             merge->addItem(name);
         }
         merge->setCurrentIndex(-1);
@@ -384,7 +384,7 @@ void PsdWidget::Private::applyAttributes()
     }
 
     for (const auto &row : rows) {
-        const auto item = model.data(row, PsdTreeItemModel::Roles::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
+        const auto item = model.data(row, PsdTreeItemModel::LayerItemObjectRole).value<const QPsdAbstractLayerItem *>();
         auto hint = item->exportHint();
         if (type > -1)
             hint.type = static_cast<QPsdAbstractLayerItem::ExportHint::Type>(type);
@@ -451,7 +451,7 @@ void PsdWidget::load(const QString &fileName)
     std::function<void(const QModelIndex &index)> traverseTreeView;
     traverseTreeView = [&](const QModelIndex &index) {
         if (d->model.hasChildren(index)) {
-            const auto lyid = d->model.data(index, PsdTreeItemModel::Roles::LayerIdRole).toInt();
+            const auto lyid = d->model.data(index, PsdTreeItemModel::LayerIdRole).toInt();
             d->treeView->setExpanded(index, d->settings.value(u"%1-x"_s.arg(lyid), false).toBool());
 
             for (int row = 0; row < d->model.rowCount(index); row++) {


### PR DESCRIPTION
PsdTreeItemModel は QPsdGuiLayerTreeItemModel を継承するようにして、
PsdView, PsdWidget からdata() を呼び出していた箇所をアクセスメソッドを呼ぶように整理しました