### PR TITLE
Fix merge group

### DIFF
--- a/src/psdcore/qpsdlayertreeitemmodel.cpp
+++ b/src/psdcore/qpsdlayertreeitemmodel.cpp
@@ -387,7 +387,6 @@ QString QPsdLayerTreeItemModel::layerName(const QModelIndex &index) const
 const QPsdLayerRecord *QPsdLayerTreeItemModel::layerRecord(const QModelIndex &index) const
 {
     int nodeIndex = index.internalId();
-    const auto node = d->treeNodeList.at(nodeIndex);
 
     return &(d->layerRecords.at(nodeIndex));
 }

--- a/src/psdcore/qpsdlayertreeitemmodel.cpp
+++ b/src/psdcore/qpsdlayertreeitemmodel.cpp
@@ -20,7 +20,11 @@ public:
         qint32 parentNodeIndex;
         enum FolderType folderType;
         bool isCloseFolder;
-        QPersistentModelIndex modelIndex;
+    };
+
+    struct IndexInfo {
+        int row = -1;
+        qint32 nodeIndex = -1;
     };
 
     Private(const ::QPsdLayerTreeItemModel *model);
@@ -34,8 +38,8 @@ public:
     QList<QPsdLayerRecord> layerRecords;
     QList<Node> treeNodeList;
     QList<int> groupIDs;
-    QMultiMap<int, QPersistentModelIndex> groupsMap;
-    QList<QPersistentModelIndex> clippingMasks;
+    QMultiMap<int, IndexInfo> groupsMap;
+    QList<IndexInfo> clippingMasks;
 };
 
 QPsdLayerTreeItemModel::Private::Private(const ::QPsdLayerTreeItemModel *model) : q(model)
@@ -300,22 +304,22 @@ void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
         }
         
         row++;
-        QModelIndex modelIndex;
+        Private::IndexInfo indexInfo;
         if (!isCloseFolder) {
-            modelIndex = createIndex(row, 0, i);
+            indexInfo = { row, i };
             
             if (i < d->groupIDs.size()) {
                 const auto groupID = d->groupIDs.at(i);
                 if (groupID > 0) {
-                    d->groupsMap.insert(groupID, modelIndex);
+                    d->groupsMap.insert(groupID, indexInfo);
                 }
             }
 
             if (record.clipping() == QPsdLayerRecord::Clipping::Base) {
                 while (d->clippingMasks.size() < d->treeNodeList.size()) {
-                    d->clippingMasks.prepend(modelIndex);
+                    d->clippingMasks.prepend(indexInfo);
                 }
-                d->clippingMasks.prepend(QModelIndex());
+                d->clippingMasks.prepend({});
             }
         }
         
@@ -335,7 +339,6 @@ void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
             parentNodeIndex,
             folderType,
             isCloseFolder,
-            modelIndex,
         });
         
         if (folderType != FolderType::NotFolder) {
@@ -349,7 +352,7 @@ void QPsdLayerTreeItemModel::fromParser(const QPsdParser &parser)
     });
 
     while (d->clippingMasks.size() < d->treeNodeList.size()) {
-        d->clippingMasks.prepend(QModelIndex());
+        d->clippingMasks.prepend({});
     }
 
     endResetModel();
@@ -400,15 +403,19 @@ QPsdLayerTreeItemModel::FolderType QPsdLayerTreeItemModel::folderType(const QMod
 QList<QPersistentModelIndex> QPsdLayerTreeItemModel::groupIndexes(const QModelIndex &index) const
 {
     int nodeIndex = index.internalId();
-    const auto list = d->groupsMap.values(d->groupIDs.at(nodeIndex));
-
-    return QList<QPersistentModelIndex>(list);
+    const auto &list = d->groupsMap.values(d->groupIDs.at(nodeIndex));
+    QList<QPersistentModelIndex> groupIndexes;
+    for (const auto &info : list) {
+        groupIndexes.append(createIndex(info.row, 0, info.nodeIndex));
+    }
+    return groupIndexes;
 }
 
 QPersistentModelIndex QPsdLayerTreeItemModel::clippingMaskIndex(const QModelIndex &index) const
 {
     int nodeIndex = index.internalId();
-    return d->clippingMasks.at(nodeIndex);
+    const auto &info = d->clippingMasks.at(nodeIndex);
+    return createIndex(info.row, 0, info.nodeIndex);
 }
 
 QT_END_NAMESPACE


### PR DESCRIPTION
Merge to の選択肢が正しく表示されない問題を修正しました

以前からおかしかったということも確認しましたが、現時点のコードの問題は
622132cb25d9f45c313bc29ba9a7a119e1780233 の修正で fromParser の処理で QAbstractItemModel の 
endResetModel を呼び出すようにしたのですが、このメソッドではそれまでに生成された QModelIndex をすべて
(QAbstractItemModel が記憶していて) invalidate する処理が実行されており、fromParser で生成した
group と clippingMask の情報がすべて破棄されてしまっていました。

このため、QModelIndex で保持するのをやめて IndexInfo 構造体で row と nodeIndex だけ保持して
data() で取得する際に QModelIndex を生成して返却するように修正して解決しました
