### PR TITLE
update hint of QPsdLayerTree

### DIFF
--- a/src/apps/psdexporter/psdtreeitemmodel.h
+++ b/src/apps/psdexporter/psdtreeitemmodel.h
@@ -52,6 +52,9 @@ public:
     QVariantMap exportHint(const QString& exporterKey) const;
     void updateExportHint(const QString &key, const QVariantMap &hint);
 
+    QPsdAbstractLayerItem::ExportHint layerHint(const QModelIndex &index) const;
+    void setLayerHint(const QModelIndex &index, const QPsdAbstractLayerItem::ExportHint exportHint);
+
 public slots:
     void load(const QString &fileName);
     void save();

--- a/src/apps/psdexporter/psdwidget.cpp
+++ b/src/apps/psdexporter/psdwidget.cpp
@@ -432,7 +432,7 @@ void PsdWidget::Private::applyAttributes()
 
         hint.properties = propertiesChecked;
 
-        item->setExportHint(hint);
+        model.setLayerHint(row, hint);
     }
 }
 


### PR DESCRIPTION
現状は QPsdLayerTreeItemModel と QPsdLayerTree のそれぞれで QPsdAbstractLayerItem を生成していて
後者から前者に移行しようとしているのですが、エクスポート処理はまだ後者に依存しているため、
exportHint の編集結果を後者の QPsdLayerTree に反映させる処理を実装しました
