### PR TITLE
emit dataChanged at setLayerHint

### DIFF
--- a/src/apps/psdexporter/psdtreeitemmodel.cpp
+++ b/src/apps/psdexporter/psdtreeitemmodel.cpp
@@ -356,6 +356,8 @@ void PsdTreeItemModel::setLayerHint(const QModelIndex &index, const QPsdAbstract
 
     d->layerHints.insert(idstr, exportHint);
     item->setExportHint(exportHint);
+
+    emit dataChanged(index, index);
 }
 
 void PsdTreeItemModel::load(const QString &fileName)


### PR DESCRIPTION
applyボタン押下時 = setLayerHint 呼び出し時に dataChanged シグナルを emit することで
checkModifiedAndSaved が正しく判定できるようにしました

ItemExportSettingDialog での更新は PsdView (PsdAbstractItem) の対応が必要で、まだ未対応です