### PR TITLE
call setLayerHint after accept ItemExportSettingDialog

### DIFF
--- a/src/apps/psdexporter/psdabstractitem.cpp
+++ b/src/apps/psdexporter/psdabstractitem.cpp
@@ -9,7 +9,7 @@
 class PsdAbstractItem::Private
 {
 public:
-    Private(const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, PsdAbstractItem *parent);
+    Private(const QModelIndex &index, const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, PsdAbstractItem *parent);
 
 private:
     PsdAbstractItem *q;
@@ -17,19 +17,20 @@ public:
     const QPsdAbstractLayerItem *layer = nullptr;
     const QPsdAbstractLayerItem *maskItem = nullptr;
     const QMap<quint32, QString> group;
+    const QModelIndex index;
 };
 
-PsdAbstractItem::Private::Private(const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, PsdAbstractItem *parent)
+PsdAbstractItem::Private::Private(const QModelIndex &index, const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, PsdAbstractItem *parent)
     : q(parent)
-    , layer(layer), maskItem(maskItem), group(group)
+    , layer(layer), maskItem(maskItem), group(group), index(index)
 {
     q->setVisible(layer->isVisible());
     q->setGeometry(layer->rect());
 }
 
-PsdAbstractItem::PsdAbstractItem(const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
+PsdAbstractItem::PsdAbstractItem(const QModelIndex &index, const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
     : QWidget(parent)
-    , d(new Private(layer, maskItem, group, this))
+    , d(new Private(index, layer, maskItem, group, this))
 {}
 
 PsdAbstractItem::~PsdAbstractItem() = default;
@@ -78,4 +79,9 @@ const QPsdAbstractLayerItem *PsdAbstractItem::abstractLayer() const
 QMap<quint32, QString> PsdAbstractItem::groupMap() const
 {
     return d->group;
+}
+
+QModelIndex PsdAbstractItem::modelIndex() const
+{
+    return d->index;
 }

--- a/src/apps/psdexporter/psdabstractitem.h
+++ b/src/apps/psdexporter/psdabstractitem.h
@@ -15,13 +15,14 @@ class PsdAbstractItem : public QWidget
 {
     Q_OBJECT
 public:
-    PsdAbstractItem(const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
+    PsdAbstractItem(const QModelIndex &index, const QPsdAbstractLayerItem *layer, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
     ~PsdAbstractItem();
 
     quint32 id() const;
     QString name() const;
     const QPsdAbstractLayerItem *abstractLayer() const;
     QMap<quint32, QString> groupMap() const;
+    QModelIndex modelIndex() const;
 
 protected:
     void setMask(QPainter *painter) const;

--- a/src/apps/psdexporter/psdfolderitem.cpp
+++ b/src/apps/psdexporter/psdfolderitem.cpp
@@ -4,8 +4,8 @@
 #include "psdfolderitem.h"
 #include <QtGui/QPainter>
 
-PsdFolderItem::PsdFolderItem(const QPsdFolderLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
-    : PsdAbstractItem(psdData, maskItem, group, parent)
+PsdFolderItem::PsdFolderItem(const QModelIndex &index, const QPsdFolderLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
+    : PsdAbstractItem(index, psdData, maskItem, group, parent)
 {}
 
 void PsdFolderItem::paintEvent(QPaintEvent *event)

--- a/src/apps/psdexporter/psdfolderitem.h
+++ b/src/apps/psdexporter/psdfolderitem.h
@@ -11,7 +11,7 @@ class PsdFolderItem : public PsdAbstractItem
 {
     Q_OBJECT
 public:
-    PsdFolderItem(const QPsdFolderLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
+    PsdFolderItem(const QModelIndex &index, const QPsdFolderLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/src/apps/psdexporter/psdimageitem.cpp
+++ b/src/apps/psdexporter/psdimageitem.cpp
@@ -7,8 +7,8 @@
 #include <QtGui/QPainter>
 #include <QtPsdCore/QPsdSofiEffect>
 
-PsdImageItem::PsdImageItem(const QPsdImageLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
-    : PsdAbstractItem(psdData, maskItem, group, parent)
+PsdImageItem::PsdImageItem(const QModelIndex &index, const QPsdImageLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
+    : PsdAbstractItem(index, psdData, maskItem, group, parent)
 {}
 
 void PsdImageItem::paintEvent(QPaintEvent *event)

--- a/src/apps/psdexporter/psdimageitem.h
+++ b/src/apps/psdexporter/psdimageitem.h
@@ -11,7 +11,7 @@ class PsdImageItem : public PsdAbstractItem
 {
     Q_OBJECT
 public:
-    PsdImageItem(const QPsdImageLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
+    PsdImageItem(const QModelIndex &index, const QPsdImageLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/src/apps/psdexporter/psdshapeitem.cpp
+++ b/src/apps/psdexporter/psdshapeitem.cpp
@@ -9,8 +9,8 @@
 #include <QtPsdGui/QPsdBorder>
 #include <QtPsdGui/QPsdPatternFill>
 
-PsdShapeItem::PsdShapeItem(const QPsdShapeLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
-    : PsdAbstractItem(psdData, maskItem, group, parent)
+PsdShapeItem::PsdShapeItem(const QModelIndex &index, const QPsdShapeLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
+    : PsdAbstractItem(index, psdData, maskItem, group, parent)
 {}
 
 void PsdShapeItem::paintEvent(QPaintEvent *event)

--- a/src/apps/psdexporter/psdshapeitem.h
+++ b/src/apps/psdexporter/psdshapeitem.h
@@ -11,7 +11,7 @@ class PsdShapeItem : public PsdAbstractItem
 {
     Q_OBJECT
 public:
-    PsdShapeItem(const QPsdShapeLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
+    PsdShapeItem(const QModelIndex &index, const QPsdShapeLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/src/apps/psdexporter/psdtextitem.cpp
+++ b/src/apps/psdexporter/psdtextitem.cpp
@@ -6,8 +6,8 @@
 #include <QtGui/QPainter>
 #include <QtGui/QWindow>
 
-PsdTextItem::PsdTextItem(const QPsdTextLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
-    : PsdAbstractItem(psdData, maskItem, group, parent)
+PsdTextItem::PsdTextItem(const QModelIndex &index, const QPsdTextLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent)
+    : PsdAbstractItem(index, psdData, maskItem, group, parent)
 {}
 
 void PsdTextItem::paintEvent(QPaintEvent *event)

--- a/src/apps/psdexporter/psdtextitem.h
+++ b/src/apps/psdexporter/psdtextitem.h
@@ -11,7 +11,7 @@ class PsdTextItem : public PsdAbstractItem
 {
     Q_OBJECT
 public:
-    PsdTextItem(const QPsdTextLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
+    PsdTextItem(const QModelIndex &index, const QPsdTextLayerItem *psdData, const QPsdAbstractLayerItem *maskItem, const QMap<quint32, QString> group, QWidget *parent = nullptr);
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/src/apps/psdexporter/psdview.cpp
+++ b/src/apps/psdexporter/psdview.cpp
@@ -103,16 +103,16 @@ void PsdView::reset()
             PsdAbstractItem *item = nullptr;
             switch (layer->type()) {
             case QPsdAbstractLayerItem::Text: {
-                item = new PsdTextItem(reinterpret_cast<const QPsdTextLayerItem *>(layer), mask, groupMap, parent);
+                item = new PsdTextItem(index, reinterpret_cast<const QPsdTextLayerItem *>(layer), mask, groupMap, parent);
                 break; }
             case QPsdAbstractLayerItem::Shape: {
-                item = new PsdShapeItem(reinterpret_cast<const QPsdShapeLayerItem *>(layer), mask, groupMap, parent);
+                item = new PsdShapeItem(index, reinterpret_cast<const QPsdShapeLayerItem *>(layer), mask, groupMap, parent);
                 break; }
             case QPsdAbstractLayerItem::Image: {
-                item = new PsdImageItem(reinterpret_cast<const QPsdImageLayerItem *>(layer), mask, groupMap, parent);
+                item = new PsdImageItem(index, reinterpret_cast<const QPsdImageLayerItem *>(layer), mask, groupMap, parent);
                 break; }
             case QPsdAbstractLayerItem::Folder: {
-                item = new PsdFolderItem(reinterpret_cast<const QPsdFolderLayerItem *>(layer), mask, groupMap, parent);
+                item = new PsdFolderItem(index, reinterpret_cast<const QPsdFolderLayerItem *>(layer), mask, groupMap, parent);
                 item->resize(size());
                 parent = item;
                 break; }
@@ -178,6 +178,7 @@ void PsdView::mouseDoubleClickEvent(QMouseEvent *event)
         dialog.setItem(child->abstractLayer(), child->groupMap());
         if (dialog.exec() == QDialog::Accepted) {
             emit updateText(child->abstractLayer());
+            d->model->setLayerHint(child->modelIndex(), child->abstractLayer()->exportHint());
         }
 
         d->rubberBand->hide();

--- a/src/apps/psdexporter/psdwidget.cpp
+++ b/src/apps/psdexporter/psdwidget.cpp
@@ -3,7 +3,6 @@
 
 #include "psdwidget.h"
 #include "ui_psdwidget.h"
-#include "itemexportsettingdialog.h"
 #include "psdtreeitemmodel.h"
 
 #include <QtCore/QCryptographicHash>


### PR DESCRIPTION
ItemExportSettingDialog で変更した場合(PsdView をダブルクリックして変更した場合) に
ExportHint が正しく反映されない問題を修正しました