### PR TITLE
remove the dependency on QtGui from PsdCore

### DIFF
--- a/src/psdcore/qpsdtypetoolobjectsetting.cpp
+++ b/src/psdcore/qpsdtypetoolobjectsetting.cpp
@@ -9,7 +9,7 @@ QT_BEGIN_NAMESPACE
 class QPsdTypeToolObjectSetting::Private : public QSharedData
 {
 public:
-    QTransform transform;
+    QList<qreal> transform;
     QPsdDescriptor textData;
     QPsdDescriptor warpData;
     QRect rect;
@@ -35,8 +35,8 @@ QPsdTypeToolObjectSetting::QPsdTypeToolObjectSetting(QIODevice *source, quint32 
     auto yy = readDouble(source, length);
     auto tx = readDouble(source, length);
     auto ty = readDouble(source, length);
-    d->transform = QTransform(xx, xy, yx, yy, tx, ty);
-
+    d->transform = { xx, xy, yx, yy, tx, ty };
+ 
     // Text version ( = 50 for Photoshop 6.0)
     auto textVersion = readU16(source, length);
     Q_ASSERT(textVersion == 50);
@@ -95,7 +95,7 @@ QPsdTypeToolObjectSetting &QPsdTypeToolObjectSetting::operator=(const QPsdTypeTo
 
 QPsdTypeToolObjectSetting::~QPsdTypeToolObjectSetting() = default;
 
-QTransform QPsdTypeToolObjectSetting::transform() const
+QList<qreal> QPsdTypeToolObjectSetting::transform() const
 {
     return d->transform;
 }

--- a/src/psdcore/qpsdtypetoolobjectsetting.h
+++ b/src/psdcore/qpsdtypetoolobjectsetting.h
@@ -7,8 +7,6 @@
 #include <QtPsdCore/qpsdsection.h>
 #include <QtPsdCore/qpsddescriptor.h>
 
-#include <QtGui/QTransform>
-
 QT_BEGIN_NAMESPACE
 
 class Q_PSDCORE_EXPORT QPsdTypeToolObjectSetting : public QPsdSection
@@ -20,7 +18,7 @@ public:
     QPsdTypeToolObjectSetting &operator=(const QPsdTypeToolObjectSetting &other);
     ~QPsdTypeToolObjectSetting() override;
 
-    QTransform transform() const;
+    QList<qreal> transform() const;
     QPsdDescriptor textData() const;
     QPsdDescriptor warpData() const;
     QRect rect() const;

--- a/src/psdgui/qpsdtextlayeritem.cpp
+++ b/src/psdgui/qpsdtextlayeritem.cpp
@@ -88,7 +88,12 @@ QPsdTextLayerItem::QPsdTextLayerItem(const QPsdLayerRecord &record)
     const auto additionalLayerInformation = record.additionalLayerInformation();
     const auto tysh = additionalLayerInformation.value("TySh").value<QPsdTypeToolObjectSetting>();
     const auto textData = tysh.textData();
-    const auto transform = tysh.transform();
+    const auto transformParam = tysh.transform();
+    const QTransform transform = QTransform(
+        transformParam[0], transformParam[1],
+        transformParam[2], transformParam[3],
+        transformParam[4], transformParam[5]
+    );
 
     const auto engineDataData = textData.data().value("EngineData").toByteArray();
     const auto engineData = QPsdEngineDataParser::parseEngineData(engineDataData);


### PR DESCRIPTION
PsdCore が QtGui に依存している箇所を削除するため、戻り値を QTransform ではなく
QList<qreal> に変更しました

fix issue #8