### PR TITLE
parse ag-psd: fix height for UserSuppliedLayerMask

### DIFF
--- a/src/psdcore/qpsdchannelimagedata.cpp
+++ b/src/psdcore/qpsdchannelimagedata.cpp
@@ -72,7 +72,9 @@ QPsdChannelImageData::QPsdChannelImageData(const QPsdLayerRecord &record, QIODev
             // The RLE compressed data follows, with each scan line compressed separately.
             // The RLE compression is the same compression algorithm used by the Macintosh
             // ROM routine PackBits, and the TIFF standard.
-            d->imageData.insert(id, readRLE(source, record.rect().height(), &length));
+            d->imageData.insert(id, readRLE(source,
+                                            id == QPsdChannelInfo::UserSuppliedLayerMask ? record.layerMaskAdjustmentLayerData().rect().height() : record.rect().height(),
+                                            &length));
             break;
         default:
             qFatal("Compression %d not supported", compression);


### PR DESCRIPTION
ag-psd の layer_mask/src.psd が読み込めない問題の修正です。

UserSuppliedLayerMask はほかの channel と違って layerMaskAdjustmentLayerData の rect のサイズの画像になっているようでした
cf. https://github.com/Agamnentzar/ag-psd/blob/246446f58e22216c737060944ea5795719b9c54d/src/psdReader.ts#L567
