### PR TITLE
parse ag-psd: fix to skip RLE padding byte (0x80 == -128)

### DIFF
--- a/src/psdcore/qpsdabstractimage.cpp
+++ b/src/psdcore/qpsdabstractimage.cpp
@@ -85,11 +85,13 @@ QByteArray QPsdAbstractImage::readRLE(QIODevice *source, int height, quint32 *le
     }
     for (qint16 byteCount : byteCounts) {
         EnsureSeek es(source, byteCount);
-        while (es.bytesAvailable() > 1) {
+        while (es.bytesAvailable() > 0) {
             auto size = readS8(source, length);
-            if (size < 0) {
+            if (size == -128) {
+                // ignore size == -128 for padding
+            } else if (size < 0) {
                 ret.append(-size + 1, readByteArray(source, 1, length).at(0));
-            } else {
+            } else if (size >= 0) {
                 ret.append(readByteArray(source, size + 1, length));
             }
         }


### PR DESCRIPTION
ag-psd の rle_fail/src.psd をパースできるように修正しました。

RLE の Length が 0x80 の場合 padding として読み飛ばすようにしています。
また、bytesAvailable() > 1 の場合にループしていたのですが、パディングがある場合に
bytesAvailable() == 1 で読み飛ばすべきデータがあるのに readRLE 関数を終了してしまっていたので
ループ条件を > 0 に変更しています