### PR TITLE
fix visible

### DIFF
--- a/src/apps/psdexporter/psdtreeitemmodel.cpp
+++ b/src/apps/psdexporter/psdtreeitemmodel.cpp
@@ -200,7 +200,7 @@ bool PsdTreeItemModel::isVisible(const QModelIndex &index) const
 {
     const auto *model = dynamic_cast<const QPsdWidgetTreeItemModel *>(sourceModel());
     if (model) {
-        return model->isVisible(index);
+        return model->isVisible(mapToSource(index));
     } else {
         return {};
     }
@@ -210,6 +210,6 @@ void PsdTreeItemModel::setVisible(const QModelIndex &index, bool visible)
 {
     auto *model = dynamic_cast<QPsdWidgetTreeItemModel *>(sourceModel());
     if (model) {
-        model->setVisible(index, visible);
+        model->setVisible(mapToSource(index), visible);
     }
 }


### PR DESCRIPTION
psdexporter アプリのツリー表示のチェックボックスが正しく動作していなかったのを修正しました。

isVisible / setVisible で mapToSource を呼び出さないといけなかったのが抜けていました。すみません
