### PR TITLE
Flutter toucharea

### DIFF
--- a/src/plugins/psdexporter/flutter/flutter.cpp
+++ b/src/plugins/psdexporter/flutter/flutter.cpp
@@ -568,17 +568,22 @@ bool QPsdExporterFlutterPlugin::outputShape(const QModelIndex &shapeIndex, Eleme
     const auto *shape = dynamic_cast<const QPsdShapeLayerItem *>(model()->layerItem(shapeIndex));
     const auto hint = model()->layerHint(shapeIndex);
     const auto path = shape->pathInfo();
+    const auto id = toLowerCamelCase(hint.id);
 
     Element containerElement;
-    switch (hint.baseElement) {
-    case QPsdAbstractLayerItem::ExportHint::NativeComponent::Container:
-    default:
-        //TODO other NativeComponet are not supported yet
-        containerElement.type = "Container"_L1;
-        break;
-    case QPsdAbstractLayerItem::ExportHint::NativeComponent::TouchArea:
-        containerElement.type = "Ink"_L1;
-        break;
+    if (!id.isEmpty()) {
+        switch (hint.baseElement) {
+        case QPsdAbstractLayerItem::ExportHint::NativeComponent::Container:
+        default:
+            //TODO other NativeComponet are not supported yet
+            containerElement.type = "Container"_L1;
+            break;
+        case QPsdAbstractLayerItem::ExportHint::NativeComponent::TouchArea:
+            containerElement.type = "Ink"_L1;
+            break;
+        }
+    } else {
+        containerElement.type = "Container"_L1;        
     }
 
     Element decorationElement;
@@ -644,7 +649,7 @@ bool QPsdExporterFlutterPlugin::outputShape(const QModelIndex &shapeIndex, Eleme
         listDropShadow.append(QVariant::fromValue(effect));
     }
 
-    if (hint.baseElement == QPsdAbstractLayerItem::ExportHint::NativeComponent::TouchArea) {
+    if (!id.isEmpty() && hint.baseElement == QPsdAbstractLayerItem::ExportHint::NativeComponent::TouchArea) {
         PropertyInfo prop {
             "void Function()?"_L1, "on_%1_Tap"_L1, hint.id
         };
@@ -780,7 +785,7 @@ bool QPsdExporterFlutterPlugin::traverseTree(const QModelIndex &index, Element *
             exports->insert(prop.name(), prop);
             pElement = &visibilityElement;
         }
-
+ 
         if (existsPositioned) {
             positionedElement.properties.insert("child"_L1, QVariant::fromValue(*pElement));
             pElement = &positionedElement;

--- a/src/plugins/psdexporter/flutter/flutter.cpp
+++ b/src/plugins/psdexporter/flutter/flutter.cpp
@@ -751,7 +751,6 @@ bool QPsdExporterFlutterPlugin::traverseTree(const QModelIndex &index, Element *
         Element element;
         Element positionedElement;
         bool existsPositioned = false;
-        Element visibilityElement;
 
         switch (item->type()) {
         case QPsdAbstractLayerItem::Folder: {
@@ -775,6 +774,26 @@ bool QPsdExporterFlutterPlugin::traverseTree(const QModelIndex &index, Element *
 
         Element *pElement = &element;
 
+        Element materialElement;
+        if (!id.isEmpty() && item->type() != QPsdAbstractLayerItem::Shape
+            && hint.baseElement == QPsdAbstractLayerItem::ExportHint::NativeComponent::TouchArea) {
+            PropertyInfo prop {
+                "void Function()?"_L1, "on_%1_Tap"_L1, hint.id
+            };
+            exports->insert(prop.name(), prop);
+    
+            Element inkWell;
+            inkWell.type = "InkWell"_L1;
+            inkWell.properties.insert("onTap"_L1, prop.name());
+            inkWell.properties.insert("child"_L1, QVariant::fromValue(*pElement));
+                    
+            materialElement.type = "Material";
+            materialElement.properties.insert("type"_L1, "MaterialType.transparency"_L1);
+            materialElement.properties.insert("child"_L1, QVariant::fromValue(inkWell));
+            pElement = &materialElement;
+        }
+
+        Element visibilityElement;
         if (hint.properties.contains("visible")) {
             PropertyInfo prop {
                 "bool"_L1, "%1_visibility"_L1, hint.id, hint.visible ? "true"_L1 : "false"_L1


### PR DESCRIPTION
Flutter 向けエクスポート時に with Touch を選択した場合の処理を2点修正しました

- id が指定されていない場合はイベント名などが正しく生成できないので処理対象外としました
- 従来は Shape レイヤーのみ対応していましたが、Folder などほかの種別のレイヤーの場合にはそれを囲む位置に Material + InkWell を生成するように対応させました
