### PR TITLE
add QPsdLayerTreeItemModel#load

### DIFF
--- a/src/apps/psdexporter/psdtreeitemmodel.h
+++ b/src/apps/psdexporter/psdtreeitemmodel.h
@@ -11,8 +11,6 @@ class PsdTreeItemModel : public QPsdExporterTreeItemModel
 {
     Q_OBJECT
 
-    Q_PROPERTY(QFileInfo fileInfo READ fileInfo NOTIFY fileInfoChanged)
-
 public:
     enum Roles {
         ExportIdRole = QPsdGuiLayerTreeItemModel::LayerItemObjectRole + 10,

--- a/src/psdcore/qpsdlayertreeitemmodel.h
+++ b/src/psdcore/qpsdlayertreeitemmodel.h
@@ -4,7 +4,7 @@
 #ifndef QPSDLAYERTREEITEMMODEL_H
 #define QPSDLAYERTREEITEMMODEL_H
 
-#include "qpsdparser.h"
+#include <QtPsdCore/qpsdparser.h>
 
 #include <QAbstractItemModel>
 #include <QFileInfo>
@@ -14,6 +14,8 @@ QT_BEGIN_NAMESPACE
 class Q_PSDCORE_EXPORT QPsdLayerTreeItemModel : public QAbstractItemModel
 {
     Q_OBJECT
+
+    Q_PROPERTY(QFileInfo fileInfo READ fileInfo NOTIFY fileInfoChanged)
 
 public:
     enum Roles {
@@ -60,6 +62,20 @@ public:
     FolderType folderType(const QModelIndex &index) const;
     QList<QPersistentModelIndex> groupIndexes(const QModelIndex &index) const;
     QPersistentModelIndex clippingMaskIndex(const QModelIndex &index) const;
+
+    QFileInfo fileInfo() const;
+    QString fileName() const;
+    QString errorMessage() const;
+
+public slots:
+    void load(const QString &fileName);
+
+private slots:
+    void setErrorMessage(const QString &errorMessage);
+
+signals:
+    void fileInfoChanged(const QFileInfo &fileInfo);
+    void errorOccurred(const QString &errorMessage);
 
 private:
     class Private;

--- a/src/psdexporter/qpsdexportertreeitemmodel.h
+++ b/src/psdexporter/qpsdexportertreeitemmodel.h
@@ -15,6 +15,8 @@ class Q_PSDEXPORTER_EXPORT QPsdExporterTreeItemModel : public QIdentityProxyMode
 {
     Q_OBJECT
 
+    Q_PROPERTY(QFileInfo fileInfo READ fileInfo NOTIFY fileInfoChanged)
+
 public:
     enum Roles {
         LayerIdRole = QPsdLayerTreeItemModel::Roles::LayerIdRole,
@@ -29,6 +31,7 @@ public:
     explicit QPsdExporterTreeItemModel(QObject *parent = nullptr);
     ~QPsdExporterTreeItemModel() override;
 
+    void setSourceModel(QAbstractItemModel *sourceModel) override;
     QPsdGuiLayerTreeItemModel *guiLayerTreeItemModel() const;
 
     QHash<int, QByteArray> roleNames() const override;

--- a/src/psdwidget/qpsdview.h
+++ b/src/psdwidget/qpsdview.h
@@ -1,11 +1,11 @@
 // Copyright (C) 2024 Signal Slot Inc.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#ifndef PSDVIEW_H
-#define PSDVIEW_H
+#ifndef QPSDVIEW_H
+#define QPSDVIEW_H
 
-#include <qpsdwidgetglobal.h>
-#include "qpsdwidgettreeitemmodel.h"
+#include <QtPsdWidget/qpsdwidgetglobal.h>
+#include <QtPsdWidget/qpsdwidgettreeitemmodel.h>
 
 #include <QtWidgets/QWidget>
 
@@ -41,4 +41,4 @@ private:
 
 QT_END_NAMESPACE
 
-#endif // PSDVIEW_H
+#endif // QPSDVIEW_H


### PR DESCRIPTION
PsdCore の QPsdLayerTreeItemModel に load メソッドと fileInfo, errorMessage プロパティなどを追加して
PsdExporter の load からもそちらを呼び出すように修正しました

インターフェースを揃えるのと、リグレッションテストなどで hint ファイルを別で指定できるように拡張する準備のために役立てる想定でいます
