### PR TITLE
Remove fatal check

### DIFF
--- a/src/plugins/psdadditionallayerinformation/lrfx/lrfx.cpp
+++ b/src/plugins/psdadditionallayerinformation/lrfx/lrfx.cpp
@@ -13,6 +13,9 @@ class QPsdAdditionalLayerInformationLrFXPlugin : public QPsdAdditionalLayerInfor
 public:
     // Effects Layer info
     QVariant parse(QIODevice *source , quint32 length) const override {
+        auto cleanup = qScopeGuard([&] {
+            Q_ASSERT(length <= 3);
+        });
         QPsdEffectsLayer ret(source, &length);
         return QVariant::fromValue(ret);
     }

--- a/src/plugins/psdadditionallayerinformation/lrfx/lrfx.cpp
+++ b/src/plugins/psdadditionallayerinformation/lrfx/lrfx.cpp
@@ -13,9 +13,6 @@ class QPsdAdditionalLayerInformationLrFXPlugin : public QPsdAdditionalLayerInfor
 public:
     // Effects Layer info
     QVariant parse(QIODevice *source , quint32 length) const override {
-        auto cleanup = qScopeGuard([&] {
-            Q_ASSERT(length == 0);
-        });
         QPsdEffectsLayer ret(source, &length);
         return QVariant::fromValue(ret);
     }

--- a/src/psdcore/qpsdeffectslayer.cpp
+++ b/src/psdcore/qpsdeffectslayer.cpp
@@ -28,7 +28,6 @@ QPsdEffectsLayer::QPsdEffectsLayer(QIODevice *source, quint32 *length)
 
     // Effects count: may be 6 (for the 6 effects in Photoshop 5 and 6) or 7 (for Photoshop 7.0)
     auto effectsCount = readU16(source, length);
-    Q_ASSERT(effectsCount == 6 || effectsCount == 7);
 
     qCDebug(lcQPsdEffectsLayer) << "count =" << effectsCount;
     while (effectsCount-- > 0) {

--- a/src/psdcore/qpsdeffectslayer.cpp
+++ b/src/psdcore/qpsdeffectslayer.cpp
@@ -28,7 +28,10 @@ QPsdEffectsLayer::QPsdEffectsLayer(QIODevice *source, quint32 *length)
 
     // Effects count: may be 6 (for the 6 effects in Photoshop 5 and 6) or 7 (for Photoshop 7.0)
     auto effectsCount = readU16(source, length);
-
+    // It seems that there are PSD files that do not comply with the specifications.
+    // effectsCount == 1, e.g. ag-psd/test/read-write/animation-effects/expected.psd
+    // effectsCount == 2, 3 e.g. ag-psd/test/read-write/effects/expected.psd
+    Q_ASSERT(effectsCount == 6 || effectsCount == 7 || effectsCount == 1 || effectsCount == 2 || effectsCount  == 3);
     qCDebug(lcQPsdEffectsLayer) << "count =" << effectsCount;
     while (effectsCount-- > 0) {
         qCDebug(lcQPsdEffectsLayer) << effectsCount;


### PR DESCRIPTION
2点、過剰な assert チェックになってしまっていたものを削除しています

lrfx.cpp のほうは、Effects Layer (Photoshop 5.0) の内容で effects 自体は奇数バイトのことがありパディングなしで
詰め込まれるのですが、全体はパディングされるようで(ドキュメントにはおそらく記載がない)、全体の length をチェックすると length == 1 などで assert にひっかかってしまうファイルがあるので削除しています。

qpsdeffectslayer.cpp のほうも同様に Effects Layer (Photoshop 5.0) の内容ですが、仕様書には ”Effects count: may be 6 (for the 6 effects in Photoshop 5 and 6) or 7 (for Photoshop 7.0)” の記載があるのですが実際には 1 になっているファイルがあるようなので、これも削除しています