### PR TITLE
support zip compression

### DIFF
--- a/src/psdcore/qpsdabstractimage.cpp
+++ b/src/psdcore/qpsdabstractimage.cpp
@@ -99,6 +99,15 @@ QByteArray QPsdAbstractImage::readRLE(QIODevice *source, int height, quint32 *le
     return ret;
 }
 
+QByteArray QPsdAbstractImage::readZip(QIODevice *source, quint32 *length)
+{
+    quint32 beLength = qToBigEndian(*length);
+    QByteArray zipData = readByteArray(source, *length, length);
+    zipData.prepend(reinterpret_cast<char *>(&beLength), sizeof(quint32));
+
+    return qUncompress(zipData);
+}
+
 QByteArray QPsdAbstractImage::toImage(QPsdFileHeader::ColorMode colorMode) const
 {
     QByteArray ret;

--- a/src/psdcore/qpsdabstractimage.h
+++ b/src/psdcore/qpsdabstractimage.h
@@ -47,6 +47,7 @@ protected:
         ZipWithPrediction = 3,
     };
     static QByteArray readRLE(QIODevice *source, int height, quint32 *length);
+    static QByteArray readZip(QIODevice *source, quint32 *length);
 
 private:
     class Private;

--- a/src/psdcore/qpsdchannelimagedata.cpp
+++ b/src/psdcore/qpsdchannelimagedata.cpp
@@ -76,6 +76,10 @@ QPsdChannelImageData::QPsdChannelImageData(const QPsdLayerRecord &record, QIODev
                                             id == QPsdChannelInfo::UserSuppliedLayerMask ? record.layerMaskAdjustmentLayerData().rect().height() : record.rect().height(),
                                             &length));
             break;
+        case ZipWithPrediction:
+        case ZipWithoutPrediction:
+            d->imageData.insert(id, readZip(source, &length));
+            break;
         default:
             qFatal("Compression %d not supported", compression);
         }

--- a/src/psdcore/qpsdimagedata.cpp
+++ b/src/psdcore/qpsdimagedata.cpp
@@ -46,6 +46,10 @@ QPsdImageData::QPsdImageData(const QPsdFileHeader &header, QIODevice *source)
     case RLE:
         d->imageData = readRLE(source, header.height() * header.channels(), &length);
         break;
+    case ZipWithPrediction:
+    case ZipWithoutPrediction:
+        d->imageData = readZip(source, &length);
+        break;
     default:
         qFatal("not supported");
     }


### PR DESCRIPTION
Channel image data の Compression. 2 = ZIP without prediction, 3 = ZIP with prediction に対応させました。

ただし、ag-psd に含まれているのは 2 = ZIP without prediction のデータだけだったので、3 の場合にも同じコードで
問題ないのかが未検証です

