### PR TITLE
remove unused skip

### DIFF
--- a/src/plugins/psdeffectslayer/sofi/sofi.cpp
+++ b/src/plugins/psdeffectslayer/sofi/sofi.cpp
@@ -51,9 +51,6 @@ public:
         const auto nativeColor = readColor(source, length);
         ret.setNativeColor(nativeColor);
 
-        // TODO: figure out the reason
-        skip(source, 2, length);
-
         return ret.isEnabled() ? QVariant::fromValue(ret) : QVariant();
     }
 };


### PR DESCRIPTION
パディングが存在する場合があるためにつじつまを合わせるために skip が呼び出されているものと思われますが、
必ず存在するわけではないのでファイルによっては不要な read が行われてバッファアンダーフローになってしまっていたので
削除しました

e,g, ag-psd/test/read-write/gradient-mode/expected.psd?

パディングについては、先日の PR で lrfx.cpp のほうで length <= 3 の場合に読み飛ばすようにしたので
この削除だけで他には影響ない想定です
