### PR TITLE
Fixed the read position becomes incorrect when padding exists in size

### DIFF
--- a/src/plugins/psdeffectslayer/sofi/sofi.cpp
+++ b/src/plugins/psdeffectslayer/sofi/sofi.cpp
@@ -23,6 +23,8 @@ public:
         const auto size = readU32(source, length);
         Q_ASSERT(size == 34);
 
+        EnsureSeek es(source, size);
+
         // Version: 2
         const auto version = readU32(source, length);
         Q_ASSERT(version == 2);


### PR DESCRIPTION
先日 skip を削除したのですが、単に削除してしまうと読み込み位置がずれるファイルもあることがわかった
‘(ファイルによってパディングがsizeに含まれるものと含まれないものがある)ので
EnsureSeek を使って size の位置まで進めるように再修正しました。

