### PR TITLE
skip check unit for angl parameter

### DIFF
--- a/src/psdcore/qpsdvectorstrokecontentsetting.cpp
+++ b/src/psdcore/qpsdvectorstrokecontentsetting.cpp
@@ -92,7 +92,8 @@ QPsdVectorStrokeContentSetting::QPsdVectorStrokeContentSetting(QIODevice *source
         }
 
         const auto angl = descriptor.data().value("Angl").value<QPsdUnitFloat>();
-        Q_ASSERT(angl.unit() == QPsdUnitFloat::Angle);
+        // accept None: e.g. ag-psd/test/read/blend-if/src.psd
+        Q_ASSERT(angl.unit() == QPsdUnitFloat::Angle || angl.unit() == QPsdUnitFloat::None);
         d->angle = angl.value();
 
         d->dither = descriptor.data().value("Dthr").toBool();


### PR DESCRIPTION
qpsdvectorstrokecontentsetting で Angl のパラメータが QPsdUnitFloat::None になっているファイルが存在するので
assert の条件を緩めています