### PR TITLE
remove version check in ObAr plugin

### DIFF
--- a/src/plugins/psddescriptor/obar/obar.cpp
+++ b/src/plugins/psddescriptor/obar/obar.cpp
@@ -15,7 +15,7 @@ public:
     // Descriptor
     QVariant parse(QIODevice *source , quint32 *length) const override {
         const auto version = readU32(source, length);
-        Q_ASSERT(version == 16);
+        Q_UNUSED(version);
         const auto name = readString(source, length);
         Q_UNUSED(name);
         const auto sizeClassID = readU32(source, length);


### PR DESCRIPTION
ObAr plugin で version == 16 のチェックを入れたのですが実際には version == 5 のファイルも存在していて、
ag-psd の実装でも単にコメントに記載があるだけでチェックしていなかったので削除しました