### PR TITLE
add padding to QPsdAdditionalLayerInformation

### DIFF
--- a/src/psdcore/qpsdadditionallayerinformation.cpp
+++ b/src/psdcore/qpsdadditionallayerinformation.cpp
@@ -20,7 +20,7 @@ QPsdAdditionalLayerInformation::QPsdAdditionalLayerInformation()
     , d(new Private)
 {}
 
-QPsdAdditionalLayerInformation::QPsdAdditionalLayerInformation(QIODevice *source)
+QPsdAdditionalLayerInformation::QPsdAdditionalLayerInformation(QIODevice *source, int padding)
     : QPsdAdditionalLayerInformation()
 {
     // Additional Layer Information
@@ -44,7 +44,7 @@ QPsdAdditionalLayerInformation::QPsdAdditionalLayerInformation(QIODevice *source
     // Length data below, rounded up to an even byte count.
     // (**PSB**, the following keys have a length count of 8 bytes: LMsk, Lr16, Lr32, Layr, Mt16, Mt32, Mtrn, Alph, FMsk, lnk2, FEid, FXid, PxSD.
     auto length = readU32(source);
-    EnsureSeek es(source, length);
+    EnsureSeek es(source, length, padding);
 
     auto plugin = QPsdAdditionalLayerInformationPlugin::plugin(d->key);
     if (plugin) {

--- a/src/psdcore/qpsdadditionallayerinformation.h
+++ b/src/psdcore/qpsdadditionallayerinformation.h
@@ -15,7 +15,7 @@ class Q_PSDCORE_EXPORT QPsdAdditionalLayerInformation : public QPsdSection
 {
 public:
     QPsdAdditionalLayerInformation();
-    QPsdAdditionalLayerInformation(QIODevice *source);
+    QPsdAdditionalLayerInformation(QIODevice *source, int padding = 0);
     QPsdAdditionalLayerInformation(const QPsdAdditionalLayerInformation &other);
     QPsdAdditionalLayerInformation &operator=(const QPsdAdditionalLayerInformation &other);
     ~QPsdAdditionalLayerInformation() override;

--- a/src/psdcore/qpsdlayerandmaskinformation.cpp
+++ b/src/psdcore/qpsdlayerandmaskinformation.cpp
@@ -36,7 +36,7 @@ QPsdLayerAndMaskInformation::QPsdLayerAndMaskInformation(QIODevice *source)
     d->globalLayerMaskInfo = QPsdGlobalLayerMaskInfo(source);
 
     while (es.bytesAvailable() > 12) {
-        QPsdAdditionalLayerInformation ali(source);
+        QPsdAdditionalLayerInformation ali(source, 4);
         d->additionalLayerInformation.insert(ali.key(), ali.data());
     }
 }


### PR DESCRIPTION
QPsdAdditionalLayerInformation に QPsdLayerAndMaskInformation から呼ばれたときのみ padding 処理を追加しています。

この処理を追加することで、

> skipping 3 bytes to find right signature

の warning を回避できるようです