### PR TITLE
Refactor QPsdAbstractImage to centralize header management

### DIFF
--- a/src/psdcore/qpsdabstractimage.cpp
+++ b/src/psdcore/qpsdabstractimage.cpp
@@ -13,8 +13,8 @@ class QPsdAbstractImage::Private : public QSharedData
 public:
     quint32 width = 0;
     quint32 height = 0;
-    quint16 depth = 0;
     quint8 opacity = 0;
+    QPsdFileHeader header;
 };
 
 QPsdAbstractImage::QPsdAbstractImage()
@@ -60,12 +60,9 @@ void QPsdAbstractImage::setHeight(quint32 height)
 
 quint16 QPsdAbstractImage::depth() const
 {
-    return d->depth;
-}
-
-void QPsdAbstractImage::setDepth(quint16 depth)
-{
-    d->depth = depth;
+    // Return header depth if set (non-zero), otherwise default to 8
+    quint16 headerDepth = d->header.depth();
+    return headerDepth ? headerDepth : 8;
 }
 
 quint8 QPsdAbstractImage::opacity() const
@@ -76,6 +73,16 @@ quint8 QPsdAbstractImage::opacity() const
 void QPsdAbstractImage::setOpacity(quint8 opacity)
 {
     d->opacity = opacity;
+}
+
+QPsdFileHeader QPsdAbstractImage::header() const
+{
+    return d->header;
+}
+
+void QPsdAbstractImage::setHeader(const QPsdFileHeader &header)
+{
+    d->header = header;
 }
 
 QByteArray QPsdAbstractImage::readRLE(QIODevice *source, int height, quint32 *length)

--- a/src/psdcore/qpsdabstractimage.h
+++ b/src/psdcore/qpsdabstractimage.h
@@ -25,6 +25,9 @@ public:
     quint16 depth() const;
     quint8 opacity() const;
 
+    QPsdFileHeader header() const;
+    void setHeader(const QPsdFileHeader &header);
+
     virtual QByteArray imageData() const = 0;
     virtual bool hasAlpha() const { return false; }
     QByteArray toImage(QPsdFileHeader::ColorMode colorMode) const;
@@ -32,7 +35,6 @@ public:
 protected:
     void setWidth(quint32 width);
     void setHeight(quint32 height);
-    void setDepth(quint16 depth);
     void setOpacity(quint8 opacity);
 
     virtual const unsigned char *gray() const = 0;

--- a/src/psdcore/qpsdchannelimagedata.cpp
+++ b/src/psdcore/qpsdchannelimagedata.cpp
@@ -11,7 +11,6 @@ class QPsdChannelImageData::Private : public QSharedData
 public:
     Private();
     QHash<QPsdChannelInfo::ChannelID, QByteArray> imageData;
-    QPsdFileHeader header;
 
     const unsigned char *data(QPsdChannelInfo::ChannelID channelID) const {
         if (!imageData.contains(channelID))
@@ -152,17 +151,6 @@ const unsigned char *QPsdChannelImageData::a() const
         alpha = d->data(QPsdChannelInfo::Alpha);
     }
     return alpha;
-}
-
-QPsdFileHeader QPsdChannelImageData::header() const
-{
-    return d->header;
-}
-
-void QPsdChannelImageData::setHeader(const QPsdFileHeader &header)
-{
-    d->header = header;
-    setDepth(header.depth());
 }
 
 QT_END_NAMESPACE

--- a/src/psdcore/qpsdchannelimagedata.h
+++ b/src/psdcore/qpsdchannelimagedata.h
@@ -26,9 +26,6 @@ public:
     QByteArray transparencyMaskData() const;
     QByteArray userSuppliedLayerMask() const;
 
-    QPsdFileHeader header() const;
-    void setHeader(const QPsdFileHeader &header);
-
 protected:
     const unsigned char *gray() const override;
     const unsigned char *r() const override;

--- a/src/psdcore/qpsdimagedata.cpp
+++ b/src/psdcore/qpsdimagedata.cpp
@@ -20,9 +20,9 @@ QPsdImageData::QPsdImageData()
 QPsdImageData::QPsdImageData(const QPsdFileHeader &header, QIODevice *source)
     : QPsdImageData()
 {
+    setHeader(header);
     setWidth(header.width());
     setHeight(header.height());
-    setDepth(header.depth());
 
     // Image Data Section
     // https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_89817


### PR DESCRIPTION
## Summary
- Move `header()` and `setHeader()` methods from `QPsdChannelImageData` to parent class `QPsdAbstractImage`
- Remove `setDepth()` method and redundant depth storage
- Update `depth()` to return value from header with fallback to 8-bit

## Motivation
This refactoring improves the design by:
- Providing a consistent interface for header access across all image implementations
- Eliminating redundant storage (depth is always from header)
- Simplifying the API (one less setter to manage)
- Ensuring consistency between depth and header values

## Changes
1. **QPsdAbstractImage**:
   - Added `header` member to Private class
   - Added `header()` and `setHeader()` methods
   - Removed `setDepth()` method and `depth` member
   - Updated `depth()` to return `header.depth()` with 8-bit fallback

2. **QPsdChannelImageData**:
   - Removed duplicate `header()` and `setHeader()` methods
   - Removed `header` member from Private class

3. **QPsdImageData**:
   - Added `setHeader()` call in constructor
   - Removed `setDepth()` call

## Test plan
- [x] Build passes
- [x] Core unit tests pass (tst_qpsdenginedataparser, tst_qpsdlayertreeitemmodel)
- [ ] Manual testing with PSD files

🤖 Generated with [Claude Code](https://claude.ai/code)