### PR TITLE
Fix additional color space reading issues in layer info plugins

### DIFF
--- a/src/plugins/psdadditionallayerinformation/anno/anno.cpp
+++ b/src/plugins/psdadditionallayerinformation/anno/anno.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QtPsdCore/qpsdadditionallayerinformationplugin.h>
+#include <QtPsdCore/qpsdcolorspace.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -36,8 +37,9 @@ public:
             Q_UNUSED(iconLocation);
             const auto popupLocation = readRectangle(source, &length);
             Q_UNUSED(popupLocation);
-            const auto color = readColor(source, &length);
-            Q_UNUSED(color);
+            const auto colorSpace = readColorSpace(source, &length);
+            const auto color = colorSpace.toString();
+            Q_UNUSED(color); // TODO: Store annotation color when Anno structure is implemented
             const auto author = readPascalString(source, 2, &length);
             Q_UNUSED(author);
             const auto name = readPascalString(source, 2, &length);

--- a/src/plugins/psdadditionallayerinformation/fmsk/fmsk.cpp
+++ b/src/plugins/psdadditionallayerinformation/fmsk/fmsk.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QtPsdCore/qpsdadditionallayerinformationplugin.h>
+#include <QtPsdCore/qpsdcolorspace.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -17,8 +18,8 @@ public:
         });
 
         // Color space
-        auto data = readByteArray(source, 10, &length);
-        Q_UNUSED(data); // TODO
+        auto colorSpace = readColorSpace(source, &length);
+        Q_UNUSED(colorSpace); // TODO: Store filter mask color when FMsk structure is implemented
 
         // Opacity
         auto opacity = readU16(source, &length);

--- a/src/plugins/psdadditionallayerinformation/grdm/grdm.cpp
+++ b/src/plugins/psdadditionallayerinformation/grdm/grdm.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QtPsdCore/qpsdadditionallayerinformationplugin.h>
+#include <QtPsdCore/qpsdcolorspace.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -36,10 +37,11 @@ public:
             Q_UNUSED(location);
             const auto midpoint = readU32(source, &length);
             Q_UNUSED(midpoint);
-            const auto color = readColor(source, &length);
-            Q_UNUSED(color);
+            const auto colorSpace = readColorSpace(source, &length);
+            const auto color = colorSpace.toString();
+            Q_UNUSED(color); // TODO: Store gradient stop color when Grdm structure is implemented
 
-            skip(source, 2, &length);
+            skip(source, 2, &length); // Unknown padding
         }
 
         const auto countTransparencyStops = readU16(source, &length);

--- a/src/plugins/psdadditionallayerinformation/phfl/phfl.cpp
+++ b/src/plugins/psdadditionallayerinformation/phfl/phfl.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QtPsdCore/qpsdadditionallayerinformationplugin.h>
+#include <QtPsdCore/qpsdcolorspace.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -20,8 +21,9 @@ public:
         Q_ASSERT(version == 2 || version == 3);
 
         if (version == 2) {
-            const auto color = readColor(source, &length);
-            Q_UNUSED(color);
+            const auto colorSpace = readColorSpace(source, &length);
+            const auto color = colorSpace.toString();
+            Q_UNUSED(color); // TODO: Store photo filter color when Phfl structure is implemented
         } else {
             const auto l = readS32(source, &length);
             const auto a = readS32(source, &length);


### PR DESCRIPTION
## Summary
This PR fixes the remaining color space reading issues that were not included in the merged PR #96.

## Changes
- **fmsk.cpp** (Filter Mask) - Replace `readByteArray(10)` with `readColorSpace()`
- **anno.cpp** (Annotations) - Fix `readColor()` usage to use `readColorSpace()`
- **grdm.cpp** (Gradient Map) - Fix `readColor()` usage for gradient stop colors
- **phfl.cpp** (Photo Filter v2) - Fix `readColor()` usage for version 2

## Context
These fixes were originally part of the second commit in PR #96 but were not included when that PR was merged. All these plugins were incorrectly reading color data without properly handling the color space ID that precedes the color components according to the Adobe PSD specification.

## Test plan
- [x] Build passes successfully
- [ ] Test with PSD files containing filter masks, annotations, gradient maps, and photo filters
- [ ] Verify that color data is read correctly with proper color space handling

🤖 Generated with [Claude Code](https://claude.ai/code)