### PR TITLE
Fix model reset and empty path handling

### DIFF
--- a/src/psdexporter/qpsdexportertreeitemmodel.cpp
+++ b/src/psdexporter/qpsdexportertreeitemmodel.cpp
@@ -126,13 +126,14 @@ QPsdExporterTreeItemModel::~QPsdExporterTreeItemModel()
 
 void QPsdExporterTreeItemModel::setSourceModel(QAbstractItemModel *source)
 {
+    QIdentityProxyModel::setSourceModel(source);
+
     beginResetModel();
     for (const auto &conn: d->sourceConnections) {
         disconnect(conn);
     }
     d->sourceConnections.clear();
 
-    QIdentityProxyModel::setSourceModel(source);
     QPsdLayerTreeItemModel *model = dynamic_cast<QPsdLayerTreeItemModel *>(source);
     d->sourceConnections = QList<QMetaObject::Connection> {
         connect(source, &QAbstractItemModel::modelReset, this, [this]() {

--- a/src/psdexporter/qpsdimagestore.cpp
+++ b/src/psdexporter/qpsdimagestore.cpp
@@ -11,7 +11,8 @@ QT_BEGIN_NAMESPACE
 class QPsdImageStore::Private : public QSharedData {
 public:
     Private(const QDir &d, const QString &p) : dir(d), path(p) {
-        dir.mkpath(path);
+        if (!path.isEmpty())
+            dir.mkpath(path);
     }
 
     const QDir dir;
@@ -25,7 +26,7 @@ public:
     QString sha256file(const QDir &dir, const QString &filename);
 };
 
-QPsdImageStore::QPsdImageStore(const QDir &dir, const QString &path) 
+QPsdImageStore::QPsdImageStore(const QDir &dir, const QString &path)
     : d(new Private(dir, path))
 {
 }
@@ -87,7 +88,7 @@ QString QPsdImageStore::save(const QString &filename, const QImage &image, const
             }
         }
 
-        // increment filename and retry    
+        // increment filename and retry
         fname = u"%1_%2.%3"_s.arg(fileInfo.completeBaseName()).arg(++i).arg(fileInfo.suffix());
     }
 


### PR DESCRIPTION
## Summary
This PR fixes two issues in the PSD exporter:

1. **QPsdExporterTreeItemModel**: Fix potential null pointer access during model reset
2. **QPsdImageStore**: Avoid creating directories for empty paths

## Changes

### QPsdExporterTreeItemModel
- Move `setSourceModel` call before `beginResetModel` to ensure the source model is set before any reset operations
- This prevents potential crashes when the model is accessed during reset

### QPsdImageStore  
- Add check for empty path before calling `mkpath`
- Prevents unnecessary directory creation when path is empty
- Minor whitespace cleanup

## Test plan
- [x] Build passes successfully
- [ ] Test exporter model reset behavior
- [ ] Verify image store doesn't create empty directories

🤖 Generated with [Claude Code](https://claude.ai/code)