### PR TITLE
fix rgb order

### DIFF
--- a/src/psdcore/qpsdimagedata.cpp
+++ b/src/psdcore/qpsdimagedata.cpp
@@ -83,17 +83,17 @@ const unsigned char *QPsdImageData::gray() const
 
 const unsigned char *QPsdImageData::r() const
 {
-    return g() + width() * height() * depth() / 8;
+    return gray();
 }
 
 const unsigned char *QPsdImageData::g() const
 {
-    return b() + width() * height() * depth() / 8;
+    return r() + width() * height() * depth() / 8;
 }
 
 const unsigned char *QPsdImageData::b() const
 {
-    return gray();
+    return g() + width() * height() * depth() / 8;
 }
 
 const unsigned char *QPsdImageData::c() const

--- a/src/psdgui/qpsdguiglobal.cpp
+++ b/src/psdgui/qpsdguiglobal.cpp
@@ -83,7 +83,7 @@ QImage imageDataToImage(const QPsdAbstractImage &imageData, const QPsdFileHeader
                     qFatal() << Q_FUNC_INFO << __LINE__;
                 }
             } else {
-                image = QImage(w, h, QImage::Format_RGB888);
+                image = QImage(w, h, QImage::Format_BGR888);
                 if (!image.isNull() && static_cast<size_t>(data.size()) >= static_cast<size_t>(w) * h * 3) {
                     memcpy(image.bits(), data.constData(), w * h * 3);
                 } else {
@@ -106,9 +106,9 @@ QImage imageDataToImage(const QPsdAbstractImage &imageData, const QPsdFileHeader
                     const quint16* src = reinterpret_cast<const quint16*>(data.constData());
                     quint16* dst = reinterpret_cast<quint16*>(image.bits());
                     for (quint32 i = 0; i < w * h; ++i) {
-                        *dst++ = src[0]; // R
-                        *dst++ = src[1]; // G
                         *dst++ = src[2]; // B
+                        *dst++ = src[1]; // G
+                        *dst++ = src[0]; // R
                         *dst++ = 65535;  // X (padding, full opacity)
                         src += 3;
                     }


### PR DESCRIPTION
write/layer-offsets/expected.psd の改善のため、以下の対応を行っています

- QPsdImageData::imageData() が返却する QByteArray の内容が depth 8bit, alpha なしの場合 RGB / BGR が混在していたので BGR に揃えることとした
  - QImage::Format_RGB888 は byte 単位で RGB 順
  - QImage::Format_ARGB32 は 4byte 単位で ARGB 順だが LittleEndian のため byte-order としては BGRA の順序
  - QPsdAbstractImage で imageData を生成する際には Alpha が存在しない場合出力しない、という処理なので全部 BGR (A) 順に揃えたほうが都合がよいし従来の実装もそうなっている
  - QPsdChannelImageData では Channelごとに Red/Green/Blue/Alpha を定数で識別しているので正しい実装
  - QPsdImageData では PSD上のデータはRGB 順にプレーン(Channel) ごとの配置になっているが、この順序の処理が間違っていて BGR 順として取り扱っていた

このため、修正箇所としては以下のようにしています
- QPsdGui::imageDataToImage で QImage に変換する際に QImage::Format_BGR888 を使用するように修正
- 上記 QPsdImageData でのプレーン順序の取り扱いを修正

